### PR TITLE
chore(java): Setup extension

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -103,4 +103,5 @@ groups:
           repository: schematichq/schematic-java
           mode: pull-request
         config:
+          client-class-name: BaseSchematic
           generate-unknown-as-json-node: true


### PR DESCRIPTION
This PR sets up generation for a `BaseSchematic` class that can be extended. 