### PR TITLE
chore: upgrade java generator to 2.8.1

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -93,7 +93,7 @@ groups:
   java-sdk:
     generators:
       - name: fernapi/fern-java-sdk
-        version: 1.0.7
+        version: 2.8.1
         output:
           location: maven
           coordinate: schematichq:schematichq-java


### PR DESCRIPTION
This PR upgrades you to the latest version of the java generator. 