### PR TITLE
Rename base class for c# to prevent SchematicApiApiException.

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -45,7 +45,7 @@ groups:
           api-key: ${NUGET_API_TOKEN}
         config:
           namespace: SchematicHQ.Client
-          client-class-name: SchematicApi
+          client-class-name: Schematic
           extra-dependencies:
             moq: "4.20.70"
             "Moq.Contrib.HttpClient": "1.4.0"


### PR DESCRIPTION
THIS IS A BREAKING CHANGE

Default exception is `<client-class-name>Exception` and then a more specific Api exception is named `<client-class-name>ApiException`. So with our current `client-class-name` of `SchematicApi`, this creates 2 confusing exceptions, `SchematicApiException` (base) and `SchematicApiApiException` (api specific exception). This should simplify that. 