### PR TITLE
Updating SDK docs for C#, Go, Java, Node.js, and Python

### DIFF
--- a/fern/docs/pages/developer_resources/sdks/csharp.mdx
+++ b/fern/docs/pages/developer_resources/sdks/csharp.mdx
@@ -191,6 +191,93 @@ bool flagValue = await schematic.CheckFlag(
 );
 ```
 
+## Webhook Verification
+
+Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The .NET SDK provides utility functions to verify these signatures.
+
+### Verifying Webhook Signatures
+
+When your application receives a webhook request from Schematic, you should verify its signature to ensure it's authentic:
+
+```csharp
+using SchematicHQ.Client.Webhooks.WebhookUtils;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WebhooksController : ControllerBase
+{
+    [HttpPost("schematic")]
+    public async Task<IActionResult> HandleSchematicWebhook()
+    {
+        try
+        {
+            // Read the request body
+            string body;
+            using (var reader = new StreamReader(Request.Body))
+            {
+                body = await reader.ReadToEndAsync();
+            }
+
+            // Extract headers into a dictionary
+            var headers = new Dictionary<string, string>();
+            foreach (var header in Request.Headers)
+            {
+                headers[header.Key] = header.Value;
+            }
+
+            // Each webhook has a distinct secret; you can access this via the Schematic app
+            string webhookSecret = "your-webhook-secret";
+
+            // Verify the webhook signature
+            WebhookVerifier.VerifyWebhookSignature(body, headers, webhookSecret);
+
+            // Process the webhook payload
+            // ...
+
+            return Ok();
+        }
+        catch (WebhookSignatureException ex)
+        {
+            // Handle signature verification failure
+            return Unauthorized(new { error = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            // Handle other errors
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
+}
+```
+
+### Verifying Signatures Manually
+
+If you need to verify a webhook signature outside of the context of an HTTP request, you can use the `VerifySignature` method:
+
+```csharp
+using SchematicHQ.Client.Webhooks.WebhookUtils;
+
+public bool VerifyWebhookManually(string body, string signature, string timestamp, string secret)
+{
+    try
+    {
+        WebhookVerifier.VerifySignature(body, signature, timestamp, secret);
+        Console.WriteLine("Signature verification successful!");
+        return true;
+    }
+    catch (WebhookSignatureException ex)
+    {
+        Console.WriteLine($"Signature verification failed: {ex.Message}");
+        return false;
+    }
+}
+```
+
 ## Configuration Options
 
 There are a number of configuration options that can be specified passing in `ClientOptions` as a second parameter when instantiating the Schematic client.

--- a/fern/docs/pages/developer_resources/sdks/go.mdx
+++ b/fern/docs/pages/developer_resources/sdks/go.mdx
@@ -168,17 +168,32 @@ This call is non-blocking and there is no response to check.
 If you want to record large numbers of the same event at once, or perhaps measure usage in terms of a unit like tokens or memory, you can optionally specify a quantity for your event:
 
 ```go
-client.Track(context.Background(), &schematicgo.EventBodyTrack{
-  Event: "query-tokens",
-  Company: map[string]stringh{
-    "id": "your-company-id",
-  },
-  User: map[string]string{
-    "email":   "wcoyote@acme.net",
-    "user-id": "your-user-id",
-  },
-  Quantity: schematicgo.Int(1500),
-})
+import (
+  "context"
+  "os"
+
+  option "github.com/schematichq/schematic-go/option"
+  schematicclient "github.com/schematichq/schematic-go/client"
+  schematicgo "github.com/schematichq/schematic-go"
+)
+
+func main() {
+  apiKey := os.Getenv("SCHEMATIC_API_KEY")
+  client := schematicclient.NewSchematicClient(option.WithAPIKey(apiKey))
+  defer client.Close()
+
+  client.Track(context.Background(), &schematicgo.EventBodyTrack{
+    Event: "query-tokens",
+    Company: map[string]string{
+      "id": "your-company-id",
+    },
+    User: map[string]string{
+      "email":   "wcoyote@acme.net",
+      "user-id": "your-user-id",
+    },
+    Quantity: schematicgo.Int(1500),
+  })
+}
 ```
 
 ### Creating and updating companies
@@ -380,6 +395,40 @@ func TestSomeFunctionality(t *testing.T) {
   // test code that expects the flag to be on
 }
 ```
+
+## Webhook Verification
+
+Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The Go SDK provides utility functions to verify these signatures.
+
+### Verifying Webhook Signatures
+
+When your application receives a webhook request from Schematic, you should verify its signature to ensure it's authentic. The SDK provides a simple function to verify webhook signatures:
+
+```go
+import (
+  "net/http"
+
+  "github.com/schematichq/schematic-go/webhooks"
+)
+
+func yourWebhookHandler(w http.ResponseWriter, r *http.Request) {
+  // Each webhook has a distinct secret; you can access this via the Schematic app
+  webhookSecret := "your-webhook-secret"
+
+  // Verify the webhook signature
+  // The request body is preserved for later reading
+  err := webhooks.VerifyWebhookSignature(r, webhookSecret)
+  if err != nil {
+    // The signature is invalid or there was another error
+    http.Error(w, "Invalid signature", http.StatusBadRequest)
+    return
+  }
+
+  // The signature is valid, process the webhook...
+}
+```
+
+If you want to verify a webhook signature outside of the context of a web request, you can also do that using the `webhooks.VerifySignature` function.
 
 ## Errors
 

--- a/fern/docs/pages/developer_resources/sdks/java.mdx
+++ b/fern/docs/pages/developer_resources/sdks/java.mdx
@@ -161,6 +161,70 @@ user.put("user_id", "your-user-id");
 boolean flagValue = schematic.checkFlag("some-flag-key", company, user);
 ```
 
+## Webhook Verification
+
+Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The Java SDK provides utility functions to verify these signatures.
+
+### Verifying Webhook Signatures
+
+When your application receives a webhook request from Schematic, you should verify its signature to ensure it's authentic:
+
+```java
+import com.schematic.webhook.WebhookVerifier;
+import com.schematic.webhook.WebhookSignatureException;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.BufferedReader;
+import java.io.IOException;
+
+// In your webhook endpoint handler:
+public void handleWebhook(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Read the request body
+    String body = request.getReader().lines().collect(Collectors.joining("\n"));
+
+    // Get the required headers
+    Map<String, String> headers = new HashMap<>();
+    headers.put(WebhookVerifier.WEBHOOK_SIGNATURE_HEADER,
+                request.getHeader(WebhookVerifier.WEBHOOK_SIGNATURE_HEADER));
+    headers.put(WebhookVerifier.WEBHOOK_TIMESTAMP_HEADER,
+                request.getHeader(WebhookVerifier.WEBHOOK_TIMESTAMP_HEADER));
+
+    String webhookSecret = "your-webhook-secret";
+
+    try {
+        // Verify the webhook signature
+        WebhookVerifier.verifyWebhookSignature(body, headers, webhookSecret);
+
+        // Process the webhook payload
+        // ...
+
+        response.setStatus(HttpServletResponse.SC_OK);
+    } catch (WebhookSignatureException e) {
+        // Handle signature verification failure
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("Invalid signature: " + e.getMessage());
+    }
+}
+```
+
+### Verifying Signatures Manually
+
+If you need to verify a webhook signature outside of the context of a servlet request, you can use the `verifySignature` method:
+
+```java
+import com.schematic.webhook.WebhookVerifier;
+import com.schematic.webhook.WebhookSignatureException;
+
+public void verifyWebhookManually(String body, String signature, String timestamp, String secret) {
+    try {
+        WebhookVerifier.verifySignature(body, signature, timestamp, secret);
+        System.out.println("Signature verification successful!");
+    } catch (WebhookSignatureException e) {
+        System.out.println("Signature verification failed: " + e.getMessage());
+    }
+}
+```
+
 ## Configuration Options
 
 There are a number of configuration options that can be specified using the builder when instantiating the Schematic client.
@@ -222,7 +286,13 @@ Schematic schematic = Schematic.builder()
     .build();
 ```
 
-While in offline mode, flag checks will return the default value for the flag being checked, and events will no-op. Other API calls will still be attempted as normal; offline mode does not affect these.
+When in offline mode:
+
+1. Flag checks will return the default value for the flag being checked (false by default, or as specified in flagDefaults)
+2. Events (identify and track) will be skipped completely
+3. All other API calls will use a no-op HTTP client that doesn't make actual network requests, returning empty responses
+
+This is especially useful for development, testing, or when running unit tests that shouldn't depend on the Schematic API.
 
 Offline mode works well with flag defaults:
 

--- a/fern/docs/pages/developer_resources/sdks/nodejs.mdx
+++ b/fern/docs/pages/developer_resources/sdks/nodejs.mdx
@@ -274,6 +274,187 @@ client.close();
 
 The Schematic API supports many operations beyond these, accessible via the API modules on the client, `Accounts`, `Billing`, `Companies`, `Entitlements`, `Events`, `Features`, and `Plans`.
 
+## Webhook Verification
+
+Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The SDK provides utility functions to verify these signatures.
+
+### Verifying Webhook Signatures
+
+When your application receives a webhook request from Schematic, you should verify its signature to ensure it's authentic. The SDK provides simple functions to verify webhook signatures. Here's how to use them in different frameworks:
+
+#### Express
+
+```ts
+import express from "express";
+import {
+    verifyWebhookSignature,
+    WebhookSignatureError,
+    WEBHOOK_SIGNATURE_HEADER,
+    WEBHOOK_TIMESTAMP_HEADER,
+} from "@schematichq/schematic-typescript-node";
+
+// Note: Schematic webhooks use these headers:
+// - X-Schematic-Webhook-Signature: Contains the HMAC-SHA256 signature
+// - X-Schematic-Webhook-Timestamp: Contains the timestamp when the webhook was sent
+
+const app = express();
+
+// Use a middleware that captures raw body for signature verification
+app.use(
+    "/webhooks/schematic",
+    express.json({
+        verify: (req, res, buf) => {
+            if (buf && buf.length) {
+                (req as any).rawBody = buf;
+            }
+        },
+    })
+);
+
+app.post("/webhooks/schematic", (req, res) => {
+    try {
+        const webhookSecret = "your-webhook-secret"; // Get this from the Schematic app
+
+        // Verify the webhook signature using the captured raw body
+        verifyWebhookSignature(req, webhookSecret);
+
+        // Process the webhook payload
+        const data = req.body;
+        console.log("Webhook verified:", data);
+
+        res.status(200).end();
+    } catch (error) {
+        if (error instanceof WebhookSignatureError) {
+            console.error("Webhook verification failed:", error.message);
+            return res.status(400).json({ error: error.message });
+        }
+
+        console.error("Error processing webhook:", error);
+        res.status(500).json({ error: "Internal server error" });
+    }
+});
+
+const PORT = 3000;
+app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});
+```
+
+#### Node HTTP Server
+
+```ts
+import http from "http";
+import {
+    verifySignature,
+    WebhookSignatureError,
+    WEBHOOK_SIGNATURE_HEADER,
+    WEBHOOK_TIMESTAMP_HEADER,
+} from "@schematichq/schematic-typescript-node";
+
+const webhookSecret = "your-webhook-secret"; // Get this from the Schematic app
+
+const server = http.createServer(async (req, res) => {
+    if (req.url === "/webhooks/schematic" && req.method === "POST") {
+        // Collect the request body
+        let body = "";
+        for await (const chunk of req) {
+            body += chunk.toString();
+        }
+
+        try {
+            // Get the headers
+            const signature = req.headers[WEBHOOK_SIGNATURE_HEADER.toLowerCase()] as string;
+            const timestamp = req.headers[WEBHOOK_TIMESTAMP_HEADER.toLowerCase()] as string;
+
+            // Verify the signature
+            verifySignature(body, signature, timestamp, webhookSecret);
+
+            // Process the webhook payload
+            const data = JSON.parse(body);
+            console.log("Webhook verified:", data);
+
+            res.statusCode = 200;
+            res.end();
+        } catch (error) {
+            if (error instanceof WebhookSignatureError) {
+                console.error("Webhook verification failed:", error.message);
+                res.statusCode = 400;
+                res.end(JSON.stringify({ error: error.message }));
+                return;
+            }
+
+            console.error("Error processing webhook:", error);
+            res.statusCode = 500;
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    } else {
+        res.statusCode = 404;
+        res.end();
+    }
+});
+
+const PORT = 3000;
+server.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});
+```
+
+#### Next.js API Routes
+
+```ts
+// pages/api/webhooks/schematic.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+    verifyWebhookSignature,
+    WebhookSignatureError,
+    WEBHOOK_SIGNATURE_HEADER,
+    WEBHOOK_TIMESTAMP_HEADER,
+} from "@schematichq/schematic-typescript-node";
+import { buffer } from "micro";
+
+// Schematic webhooks use these headers:
+// - X-Schematic-Webhook-Signature: Contains the HMAC-SHA256 signature
+// - X-Schematic-Webhook-Timestamp: Contains the timestamp when the webhook was sent
+
+// Disable body parsing to get the raw body
+export const config = {
+    api: {
+        bodyParser: false,
+    },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "POST") {
+        return res.status(405).end("Method not allowed");
+    }
+
+    try {
+        const webhookSecret = process.env.SCHEMATIC_WEBHOOK_SECRET!;
+        const rawBody = await buffer(req);
+
+        // Verify the webhook signature
+        verifyWebhookSignature(req, webhookSecret, rawBody);
+
+        // Parse the webhook payload
+        const payload = JSON.parse(rawBody.toString());
+        console.log("Webhook verified:", payload);
+
+        // Process the webhook event
+        // ...
+
+        res.status(200).end();
+    } catch (error) {
+        if (error instanceof WebhookSignatureError) {
+            console.error("Webhook verification failed:", error.message);
+            return res.status(400).json({ error: error.message });
+        }
+
+        console.error("Error processing webhook:", error);
+        res.status(500).json({ error: "Internal server error" });
+    }
+}
+```
+
 ## Testing
 
 ### Offline mode
@@ -302,3 +483,4 @@ const client = new SchematicClient({
 
 client.close();
 ```
+

--- a/fern/docs/pages/developer_resources/sdks/python.mdx
+++ b/fern/docs/pages/developer_resources/sdks/python.mdx
@@ -4,6 +4,11 @@ title: Python
 slug: developer_resources/sdks/python
 ---
 
+The Schematic Python Library provides convenient access to the Schematic API from
+applications written in Python.
+
+The library includes type definitions for all
+request and response fields, and offers both synchronous and asynchronous clients powered by httpx.
 
 ## Installation and Setup
 
@@ -41,7 +46,7 @@ asyncio.run(main())
 ```
 
 ## Exception Handling
-All errors thrown by the SDK will be subclasses of `ApiError`.
+All errors thrown by the SDK will be subclasses of [`ApiError`](./src/schematic/core/api_error.py).
 
 ```python
 try:
@@ -182,6 +187,126 @@ client.check_flag(
     company={"id": "your-company-id"},
     user={"user_id": "your-user-id"},
 )
+```
+
+## Webhook Verification
+
+Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The Python SDK provides utility functions to verify these signatures.
+
+### Verifying Webhook Signatures
+
+When your application receives a webhook request from Schematic, you should verify its signature to ensure it's authentic. The SDK provides simple functions to verify webhook signatures. Here's how to use them in different frameworks:
+
+#### Flask
+
+```python
+from flask import Flask, request, jsonify
+from schematic.webhook_utils import verify_webhook_signature, WebhookSignatureError
+
+app = Flask(__name__)
+
+@app.route('/webhooks/schematic', methods=['POST'])
+def schematic_webhook():
+    try:
+        # Each webhook has a distinct secret; you can access this via the Schematic app
+        webhook_secret = "your-webhook-secret"
+
+        # Verify the webhook signature
+        verify_webhook_signature(request, webhook_secret)
+
+        # Process the webhook payload
+        data = request.json
+        print(f"Webhook verified: {data}")
+
+        return "", 200
+    except WebhookSignatureError as e:
+        print(f"Webhook verification failed: {str(e)}")
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        print(f"Error processing webhook: {str(e)}")
+        return jsonify({"error": "Internal server error"}), 500
+
+if __name__ == '__main__':
+    app.run(port=3000)
+```
+
+#### Django
+
+```python
+from django.http import JsonResponse, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from schematic.webhook_utils import verify_webhook_signature, WebhookSignatureError
+
+@csrf_exempt
+def schematic_webhook(request):
+    if request.method != 'POST':
+        return HttpResponse(status=405)
+
+    try:
+        # Each webhook has a distinct secret; you can access this via the Schematic app
+        webhook_secret = "your-webhook-secret"
+
+        # Verify the webhook signature
+        verify_webhook_signature(request, webhook_secret)
+
+        # Process the webhook payload
+        data = request.json
+        print(f"Webhook verified: {data}")
+
+        return HttpResponse(status=200)
+    except WebhookSignatureError as e:
+        print(f"Webhook verification failed: {str(e)}")
+        return JsonResponse({"error": str(e)}, status=400)
+    except Exception as e:
+        print(f"Error processing webhook: {str(e)}")
+        return JsonResponse({"error": "Internal server error"}, status=500)
+```
+
+#### FastAPI
+
+```python
+from fastapi import FastAPI, Request, Response, HTTPException, Depends
+from schematic.webhook_utils import verify_webhook_signature, WebhookSignatureError
+
+app = FastAPI()
+
+async def verify_signature(request: Request):
+    # Each webhook has a distinct secret; you can access this via the Schematic app
+    webhook_secret = "your-webhook-secret"
+
+    try:
+        # Get the raw body
+        body = await request.body()
+
+        # Verify the webhook signature
+        verify_webhook_signature(request, webhook_secret, body)
+    except WebhookSignatureError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/webhooks/schematic")
+async def schematic_webhook(request: Request, _: None = Depends(verify_signature)):
+    # Process the webhook payload
+    data = await request.json()
+    print(f"Webhook verified: {data}")
+
+    return Response(status_code=200)
+```
+
+### Verifying Signatures Manually
+
+If you need to verify a webhook signature outside of the context of a web request, you can use the `verify_signature` function:
+
+```python
+from schematic.webhook_utils import verify_signature, WebhookSignatureError
+
+def verify_webhook_manually(body: str, signature: str, timestamp: str, secret: str):
+    try:
+        # Verify the signature
+        verify_signature(body, signature, timestamp, secret)
+        return True
+    except WebhookSignatureError as e:
+        print(f"Webhook verification failed: {str(e)}")
+        return False
 ```
 
 ## Advanced


### PR DESCRIPTION
These are just copies of the READMEs for those SDKs. This is to include info about verifying webhooks (and offline mode, in the case of Java).

We may also want to mention webhook verification on our [webhooks page](https://docs.schematichq.com/integrations/webhooks), but we can do that separately.