### PR TITLE
Switch to fern segment and full story integrations

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -405,9 +405,9 @@ logo:
 
 favicon: ./docs/assets/favicon.png
 
-# js:
+js:
 #   - ./docs/assets/fullstory.js
-#   - ./docs/assets/koala.js
+  - ./docs/assets/koala.js
 #   - ./docs/assets/segment.js
 
 analytics:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -405,10 +405,16 @@ logo:
 
 favicon: ./docs/assets/favicon.png
 
-js:
-  - ./docs/assets/fullstory.js
-  - ./docs/assets/koala.js
-  - ./docs/assets/segment.js
+# js:
+#   - ./docs/assets/fullstory.js
+#   - ./docs/assets/koala.js
+#   - ./docs/assets/segment.js
+
+analytics:
+  segment:
+    write-key: VPVpz27CAfDdx3roQGhSIXZhcra4dyRi
+  fullstory:
+    org-id: o-1Q7NYX-na1
 
 css: ./styles.css
 


### PR DESCRIPTION
I noticed that we were getting Koala tracks from me doing local doc development. I reached out to fern and they pointed me towards using their segment/fullstory instead of loading the scripts -- theirs _shouldn't_ send events in local dev. 

For Koala, we should be able to send over the events from segment. Once I confirm this is working, I'll disable Koala as well.

AFAICT, our current js for segment and Fullstory don't actually work. So hopefully this fixes Segment. For Fullstory, do we want it to? I know at one point fullstory sessions were expensive, and I don't think the docs stories are particularly high value right now. 