### PR TITLE
endure safe version of form-data

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "schematic",
-  "version": "0.65.1"
+  "version": "0.65.28"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -72,6 +72,8 @@ groups:
             browser:
               crypto: false
               timers: false
+            dependencies:
+              form-data: "^4.0.4"
           skipResponseValidation: true
 
   go-sdk:


### PR DESCRIPTION
the real move is to upgrade the version of the TS generator but i think that that will be a big lift so i wanted to get this out so that we're not sitting here with a vulnerable version of form-data.