### PR TITLE
[DEV-98] redirect `/security` -> `/architecture/security`

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -435,3 +435,7 @@ redirects:
   - source: "/feature_management/:slug"
     destination: "/feature-management/:slug"
     permanent: true
+  - source: "/security"
+    destination: "/architecture/security"
+    permanent: true
+


### PR DESCRIPTION
fixes a link on the marketing site while retaining any link juice. 

also /security is a common(ish) page for ppl to go to