### PR TITLE
SCHY-59 Add `useSchematicPlan` to vue docs

### DIFF
--- a/fern/docs/pages/catalog/plans.mdx
+++ b/fern/docs/pages/catalog/plans.mdx
@@ -27,6 +27,8 @@ When a trial period is defined for a plan, Schematic will ensure that the compan
 
 ![Schematic plan trial configuration example](../../assets/images/catalog/catalog-plans-trial.png)
 
+If you want to surface plan and trial information in your app (e.g. a plan name badge, trial countdown, or post-trial conversion flow), the React and Vue SDKs provide direct access to this data. See the [React SDK docs](/developer_resources/sdks/react#company-plan-information) or [Vue SDK docs](/developer_resources/sdks/vue#company-plan-information) for details.
+
 ### Plan Versions
 
 Plans in Schematic are versioned to better support a range of common monetization scenarios. Plan versions make it easy to support both larger plan iterations (e.g. annual pricing changes) as well as short term pricing experiments. 

--- a/fern/docs/pages/catalog/trials.mdx
+++ b/fern/docs/pages/catalog/trials.mdx
@@ -12,3 +12,11 @@ src="../../assets/images/catalog/catalog-plans-trial.png"
 />
 
 <Info>If you change trial configuration (e.g. whether a trial is a part of a plan, credit card requirement), any companies currently in a trial will be unaffected, and the new setting will apply going forward.</Info>
+
+## Rendering trial state in your app
+
+Once trials are configured, you can surface trial state directly in your UI. Schematic's React and Vue SDKs expose the current company's plan name, trial status, and trial end date, so you can build things like plan badges, trial countdown banners, and post-trial conversion flows without any additional API calls.
+
+For example, you can show a "Trial" chip with a countdown, prompt expired trial users to upgrade, or render a different experience for companies that converted from a trial versus those that never trialed at all.
+
+See the [React SDK docs](/developer_resources/sdks/react#company-plan-information) or [Vue SDK docs](/developer_resources/sdks/vue#company-plan-information) for usage details.

--- a/fern/docs/pages/components/advanced-usage.mdx
+++ b/fern/docs/pages/components/advanced-usage.mdx
@@ -18,7 +18,7 @@ The Schematic Components library provides several advanced features for customiz
   allowfullscreen
 ></iframe>
 
-A common billing use case is to present a user with a paywall, and then open a checkout flow to quickly allow them to upgrade their plan.
+A common billing use case is to present a user with a paywall, and then open a checkout flow to quickly allow them to upgrade their plan. If you need to show the user's current plan name in the paywall (e.g. "You're on the Free plan"), the React and Vue SDKs provide that data directly. See the [React SDK docs](/developer_resources/sdks/react#company-plan-information) or [Vue SDK docs](/developer_resources/sdks/vue#company-plan-information) for details.
 
 Imagine a user is trying to create their 6th AI-generated image, but their current plan only includes 5 images per month. You can present them a paywall explaining they are at their limit and prove an "Upgrade to the Pro Plan" button. When they click the upgrade button, you can create a seamless upgrade experience by:
 

--- a/fern/docs/pages/developer_resources/sdks/vue.mdx
+++ b/fern/docs/pages/developer_resources/sdks/vue.mdx
@@ -141,6 +141,42 @@ const {
 
 _Note: `useSchematicIsPending` is checking if entitlement data has been loaded, typically via `identify`. It should, therefore, be used to wrap flag and entitlement checks, but never the initial call to `identify`._
 
+### Company plan information
+
+To access the current company's plan and trial status, you can use the `useSchematicPlan` composable:
+
+```vue
+<script setup lang="ts">
+import { useSchematicPlan } from "@schematichq/schematic-vue";
+
+const plan = useSchematicPlan();
+</script>
+
+<template>
+  <div v-if="!plan">No plan assigned</div>
+  <div v-else>
+    <p>Current plan: {{ plan.name }}</p>
+
+    <p v-if="plan.trialStatus === 'active'">
+      Trial ends: {{ plan.trialEndDate?.toLocaleDateString() }}
+    </p>
+
+    <p v-if="plan.trialStatus === 'expired'">
+      Your trial has ended. <a href="/upgrade">Upgrade now</a>
+    </p>
+  </div>
+</template>
+```
+
+The composable returns an object with the following properties:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | The plan ID |
+| `name` | `string` | The plan name |
+| `trialEndDate` | `Date \| undefined` | The trial end date, if the company has or had a trial |
+| `trialStatus` | `"active" \| "expired" \| "converted" \| undefined` | The company's trial status: `active` if the trial is ongoing, `expired` if the trial ended without conversion, `converted` if the company converted to a paid plan, or `undefined` if the company has never trialed |
+
 ## Fallback Behavior
 
 The SDK includes built-in fallback behavior you can use to ensure your application continues to function even when unable to reach Schematic (e.g., during service disruptions or network issues).


### PR DESCRIPTION
Also link to `useSchematicPlan` throughout our docs where it makes sense