### PR TITLE
Fern support - Go caps fixes

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -125,7 +125,7 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.33.6
+        version: 1.34.8
         github:
           repository: schematichq/schematic-go
           mode: pull-request

--- a/overrides.yaml
+++ b/overrides.yaml
@@ -309,3 +309,19 @@ paths:
     get:
       x-fern-audiences:
         - public
+  /whoami:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                x-fern-type-name: GetWhoAmI_Response
+                properties:
+                  params:
+                    x-fern-type-name: GetWhoAmI_Params
+components:
+  schemas:
+    WhoAmIResponseData:
+      x-fern-type-name: WhoAmI_ResponseData
+


### PR DESCRIPTION
## Overview
This PR is a temp fix for a breaking capitalization change introduced in `fernapi/fern-go-sdk` generator v1.34.8. 

See the PR for the Generated Go SDK [here](https://github.com/SchematicHQ/schematic-go/pull/155)

## Changes Made
- `fernapi/fern-go-sdk` generator upgraded to `v1.34.8.`
- `overrides.yml` updated to correct for the breaking capitalization change.

## Testing
Tested against all SDKs to ensure it didn't affect name generation for WhoAmI-related types

See the PR for the Generated Go SDK [here](https://github.com/SchematicHQ/schematic-go/pull/155) (same as above)

## Future
Once the breaking capitalization change has been fixed, this commit: 19ddb4267f85497ec6c7b697fced50c3df229027 can be reverted.

