### PR TITLE
fix: configure generators to avoid downstream SDK breakage

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -44,6 +44,12 @@ groups:
                 - LocalCache
                 - Schematic
                 - SchematicConfig
+          extras:
+            datastream:
+              - "websockets>=10.0"
+              - "wasmtime>=19.0.0"
+            rulesengine:
+              - "wasmtime>=19.0.0"
         smart-casing: false
   csharp-sdk:
     generators:
@@ -63,6 +69,7 @@ groups:
           extra-dependencies:
             moq: 4.20.70
             Moq.Contrib.HttpClient: 1.4.0
+          generate-mock-server-tests: false
         smart-casing: false
   ts-sdk:
     generators:


### PR DESCRIPTION
## Summary

Three downstream issues that surfaced during the last generator bump (PR #285) are addressable via generator config rather than by patching the output files in each downstream PR:

- **python**: `fern-python-sdk` v4.64.1 overwrites `poetry.lock` but strips the `[tool.poetry.extras]` section (`websockets`, `wasmtime`) that the hand-maintained `pyproject.toml` declares, causing `poetry install --extras datastream` to fail in CI. Declare the extras in the generator config so the lock file is regenerated consistent with them.
- **csharp**: `fern-csharp-sdk` v2.61.2 regressed the MockServer test generator, emitting `List<List<T>>` initializers for `IEnumerable<T>` request fields. Disable MockServer test generation entirely — same posture we already have for Go (`enableWireTests: false`) and Java (`enable-wire-tests: false`).
- **java**: the regenerated `build.gradle` strips the chicory and jedis `implementation` deps that the hand-written `datastream/` and `cache/` code requires, causing `compileJava` to fail. Declare them in the generator's `custom-dependencies` so they survive regeneration — same mechanism we already use for test-only deps (mockito).