### PR TITLE
Remove moq dependency from C# client

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -66,9 +66,6 @@ groups:
           namespace: SchematicHQ.Client
           client-class-name: SchematicApi
           exported-client-class-name: Schematic
-          extra-dependencies:
-            moq: 4.20.70
-            Moq.Contrib.HttpClient: 1.4.0
           generate-mock-server-tests: false
         smart-casing: false
   ts-sdk:


### PR DESCRIPTION
This dependency is only used in the test project and shouldn't be getting added to the client. 

