### PR TITLE
Fern support - Remove Temp Overlays

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -126,7 +126,7 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.38.0
+        version: 1.38.1
         github:
           repository: schematichq/schematic-go
           mode: pull-request

--- a/overrides.yaml
+++ b/overrides.yaml
@@ -298,19 +298,3 @@ paths:
     get:
       x-fern-audiences:
         - public
-  /whoami:
-    get:
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                x-fern-type-name: GetWhoAmI_Response
-                properties:
-                  params:
-                    x-fern-type-name: GetWhoAmI_Params
-components:
-  schemas:
-    WhoAmIResponseData:
-      x-fern-type-name: WhoAmI_ResponseData
-


### PR DESCRIPTION
## Overview
This PR removes the overrides that were added as a temporary fix in #287. 

The capitalization issue that PR #287 fixed is now fixed in the generator code itself, so the commits in #287 can be reverted.

## Changes
- Temp Overrides removed
- Go upgraded to 1.38.1

## Generated SDK
Go SDK PR generated from commit 717219be45b29f90bf8be1df55c6265d5c362c9d on this branch: [PR](https://github.com/SchematicHQ/schematic-go/pull/160)
