### PR TITLE
Upgrade fern docs and turn on mobile-toc

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -473,6 +473,7 @@ layout:
   page-width: full
   tabs-placement: header
   searchbar-placement: header
+  mobile-toc: true
 
 settings:
   dark-mode-code: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "schematic",
-  "version": "4.76.1"
+  "version": "5.6.0"
 }


### PR DESCRIPTION
saw fern added the ability to do a mobile table of contents (screenshot is this in "tablet" size, but works on smaller screens when the left nav drops too) 

Additionally, I wanted to use the new Availability status (alpha, beta, preview, etc.) at one point for some of our SDK changes, but we didn't have that -- now we do!

<img width="1142" height="530" alt="Screenshot 2026-05-01 at 9 28 03 AM" src="https://github.com/user-attachments/assets/0f5f11e3-d377-4fb3-ad19-bd7515c4178b" />

To get this I had to upgrade to 5.6.0. I asked claude to generate a list of key changes since 4.76.1 and here's what it said:

```
Breaking change in 5.0.0 (the only real one)                                                                        
                                                                                                                      
  - og:background-image renamed to og:dynamic:background-image in docs.yml. Old key still works as a fallback, but the
   new one wins when both are set. If you set this OG image key, rename it.                                           
                                                                                    
  Notable docs/CLI features (4.77 → 5.6)                                                                              
                                                                                                                   
  - i18n / translations: BCP 47 locale tags accepted in docs.yml; simplified string syntax for translations;          
  per-locale navbar-link overrides; YAML overlays for translating navigation labels; fern check validates locale      
  directories.                                                                      
  - Multi-source instances: new multi-source property on docs.yml instances (5.x).                                    
  - Availability statuses: adds alpha, beta, preview, legacy (in addition to existing deprecated/ga).                 
  - WebSocket display: new websocket-oneof-display setting in docs.yml.                                               
  - GraphQL: spec support in fern.yml with docs rendering (cli-v2 path).                                              
  - Discriminated oneOf: base properties now inferred from variants.                                                  
  - Auth: service-level auth can be optional in Fern Definition.                                                      
  - New command: fern automations upgrade.                                                                            
  - Windows: long-path check is now a hard error for fern docs dev.                                                   
                                                                                                                      
  SDK-generator features (only matters if you regenerate SDKs)                                                        
                                                                                                                   
  - Across TS/Python/Go/Java/C#/Ruby/PHP/Swift/Rust: retryStatusCodes config with legacy/recommended modes.           
  - TS: alwaysSendAuth to override endpoint auth.                                                                     
  - PHP/Ruby: clientDefault support (Ruby note flags a breaking change for clientDefault headers, e.g. X-API-Version  
  becomes api_version.to_s in generated code).                                                                        
                                                                                                                    
  Practical upgrade checklist for this repo                                                                           
                                                                                                                      
  1. Search fern/docs.yml for og:background-image and rename it.                    
  2. Run fern check after the bump and let it surface any locale/translation issues.                                  
  3. If you regenerate any SDKs from this config, review the new retryStatusCodes defaults before publishing.  
```
[X] Search fern/docs.yml for og:background-image and rename it.                    
[X ] Run fern check after the bump and let it surface any locale/translation issues.                                  
~[ ] If you regenerate any SDKs from this config, review the new retryStatusCodes defaults before publishing.~ (generators use pinned versions, unaffected by this change
