### PR TITLE
chore(ci): use GITHUB_TOKEN for regenerate-sdks workflow

### DIFF
--- a/.github/workflows/regenerate-sdks.yml
+++ b/.github/workflows/regenerate-sdks.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -22,7 +23,7 @@ jobs:
 
       - name: Regenerate all SDKs
         env:
-          GH_TOKEN: ${{ secrets.SDK_RELEASE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Map fern group names to release workflow filenames
           workflow_file() {
@@ -41,7 +42,7 @@ jobs:
             fi
 
             # Get the latest release from the downstream repo
-            release=$(gh release view --repo "$repo" --json tagName,publishedAt 2>/dev/null || echo "")
+            release=$(gh release view --repo "$repo" --json tagName,publishedAt || echo "")
             if [ -z "$release" ]; then
               echo "Skipping $group: no releases found in $repo"
               continue


### PR DESCRIPTION
The regenerate-sdks workflow referenced `secrets.SDK_RELEASE_PAT`, which isn't configured on this repo. `GH_TOKEN` was empty, so every `gh release view` failed with an auth error — masked by `2>/dev/null` and surfaced as the misleading "no releases found" message for every SDK (see [run 25666080243](https://github.com/SchematicHQ/schematic-fern-config/actions/runs/25666080243/job/75338766874)).

The SDK repos are public and the dispatched workflows live in this same repo, so the built-in `GITHUB_TOKEN` covers both the release reads and the workflow dispatches. Adds `actions: write` so `gh workflow run` is permitted, and drops the stderr redirect so future gh failures aren't silently masked.