### PR TITLE
chore(ci): bump patch version when dispatching SDK release workflows

### DIFF
--- a/.github/workflows/regenerate-sdks.yml
+++ b/.github/workflows/regenerate-sdks.yml
@@ -50,8 +50,11 @@ jobs:
             tag=$(echo "$release" | jq -r '.tagName')
             published=$(echo "$release" | jq -r '.publishedAt')
 
-            # Strip leading 'v' if present
+            # Strip leading 'v' if present, then bump patch so this dispatch
+            # publishes a fresh version (otherwise a follow-up merge in the
+            # downstream repo would need another run here just to rev).
             version="${tag#v}"
+            version=$(echo "$version" | awk -F. '{$NF=$NF+1; OFS="."; print}')
 
             # Skip if no input changes since that release: neither the shared spec
             # files nor this group's block in generators.yml have moved.


### PR DESCRIPTION
The regenerate-sdks workflow was dispatching each SDK release with the same version as its latest release. That means after the regenerate run, doing an actual release still requires another fern-config workflow run just to rev the version. Bump the patch (e.g. `1.2.0` → `1.2.1`) so the dispatched release already targets a fresh version.