### PR TITLE
chore(docs): document trusted_client_clock and backfill event flags

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -271,6 +271,9 @@ navigation:
           - page: Creating a metered feature
             slug: metering
             path: ./docs/pages/playbooks/metering.mdx
+          - page: Backfills and usage corrections
+            slug: backfill-and-corrections
+            path: ./docs/pages/playbooks/backfill-and-corrections.mdx
           - page: Rolling out beta functionality with Flags
             slug: rollout
             path: ./docs/pages/playbooks/rollout.mdx

--- a/fern/docs/pages/api_documentation/event.mdx
+++ b/fern/docs/pages/api_documentation/event.mdx
@@ -31,7 +31,7 @@ Datetime when event was sent to Schematic. Format is ISO 8601.
 </ParamField>
 
 <ParamField path="captured_at" type="datetime">
-Datetime when event was received by Schematic. Format is ISO 8601.
+Effective timestamp of the event in Schematic. By default this is the server receipt time, but when the event is submitted with `trusted_client_clock` or `backfill`, it is the client-provided `sent_at`. Format is ISO 8601. See [Backfills and usage corrections](/playbooks/backfill-and-corrections).
 </ParamField>
 
 <ParamField path="loaded_at" type="datetime">
@@ -68,6 +68,18 @@ Current status of event in Schematic data pipeline (pending, success, failed, un
 
 <ParamField path="idempotency_key" type="string">
 Optional client-supplied key used to deduplicate events. If a second event is submitted with the same `idempotency_key` within 24 hours, scoped to the same environment and event type, it is dropped before processing.
+</ParamField>
+
+### Request-only fields
+
+Two optional boolean fields on the create-event payload let you submit events with client-provided timestamps. Both require a secret API key and a `sent_at` value. See [Backfills and usage corrections](/playbooks/backfill-and-corrections) for full semantics.
+
+<ParamField path="trusted_client_clock" type="boolean">
+When `true`, the client-provided `sent_at` is used as the effective event timestamp instead of server receipt time. Billing side effects still fire. `sent_at` must be within 5 minutes in the future and 34 days in the past.
+</ParamField>
+
+<ParamField path="backfill" type="boolean">
+When `true`, the event is stored at its `sent_at` timestamp but all billing impact, webhooks, and `last_seen_at` bumps are skipped. Intended for analytics-only imports of historical usage. `sent_at` must be within 5 minutes in the future and 365 days in the past.
 </ParamField>
 
 <Aside>

--- a/fern/docs/pages/billing/usage-based-billing.mdx
+++ b/fern/docs/pages/billing/usage-based-billing.mdx
@@ -147,7 +147,7 @@ Checkout our [Credit Burndown Docs](/billing/credit-burndown).
 Schematic supports submitting track events with **negative quantities** to reduce usage, for use cases such as refunds, corrections, or reversals. Negative quantity events must be submitted using a **secret API key** — publishable API keys will reject them.
 
 <Note>
-If the issue is that the event arrived late (the underlying usage happened earlier than the receipt time), set `trusted_client_clock: true` with the original `sent_at` instead of issuing a negative+positive pair. This attributes the usage to the correct period in both analytics and Stripe meter reporting. See [Backfills and usage corrections](/playbooks/backfill-and-corrections).
+As an alternative to sending negative values for adjustment, usage events can be backdated. If `trusted_client_clock` is `true`, clients can set their own value for `sent_at`. See [Backfills and usage corrections](/playbooks/backfill-and-corrections).
 </Note>
 
 ### How to submit a negative quantity event

--- a/fern/docs/pages/billing/usage-based-billing.mdx
+++ b/fern/docs/pages/billing/usage-based-billing.mdx
@@ -146,6 +146,10 @@ Checkout our [Credit Burndown Docs](/billing/credit-burndown).
 
 Schematic supports submitting track events with **negative quantities** to reduce usage, for use cases such as refunds, corrections, or reversals. Negative quantity events must be submitted using a **secret API key** — publishable API keys will reject them.
 
+<Note>
+If the issue is that the event arrived late (the underlying usage happened earlier than the receipt time), set `trusted_client_clock: true` with the original `sent_at` instead of issuing a negative+positive pair. This attributes the usage to the correct period in both analytics and Stripe meter reporting. See [Backfills and usage corrections](/playbooks/backfill-and-corrections).
+</Note>
+
 ### How to submit a negative quantity event
 
 Include a negative integer for the `quantity` field in your track event. The `quantity` must be a non-zero integer (fractional values are not supported).

--- a/fern/docs/pages/playbooks/backfill-and-corrections.mdx
+++ b/fern/docs/pages/playbooks/backfill-and-corrections.mdx
@@ -23,7 +23,7 @@ Both flags require a **secret API key** (`sch_` prefix) and a `sent_at` value on
 
 When `true`, Schematic uses the `sent_at` you provide as the event's effective timestamp (`captured_at`) instead of server receipt time.
 
-**Bounds on `sent_at`:**
+**Requirements for setting `sent_at`:**
 - No more than 5 minutes in the future
 - No more than **34 days** in the past
 
@@ -49,7 +49,7 @@ All normal processing still happens — billing impact, webhooks, and activity u
 
 `backfill: true` implies `trusted_client_clock` — `sent_at` is the effective timestamp — but **all billing side effects are skipped**. Use this when you want historical usage to appear in analytics without re-running billing.
 
-**Bounds on `sent_at`:**
+**Requirements for setting `sent_at` when `backfill: true`:**
 - No more than 5 minutes in the future
 - No more than **365 days** in the past
 

--- a/fern/docs/pages/playbooks/backfill-and-corrections.mdx
+++ b/fern/docs/pages/playbooks/backfill-and-corrections.mdx
@@ -1,0 +1,135 @@
+---
+title: Backfills and usage corrections
+slug: playbooks/backfill-and-corrections
+description: Submit events with client-provided timestamps to import historical usage or correct events that arrive after the fact.
+---
+
+By default, Schematic stamps every event with the time it was received. Two optional flags on the track-event payload let you override that and submit an event with the time it *actually happened*:
+
+- **`trusted_client_clock`** — use the client-provided `sent_at` as the event's effective timestamp. Billing side effects still fire (against the logical timestamp). Best for **correcting recent usage** that arrived late or with a bad timestamp.
+- **`backfill`** — analytics-only mode for **importing historical usage**. Events are stored at their logical time but skip all billing side effects.
+
+Both flags require a **secret API key** (`sch_` prefix) and a `sent_at` value on the event. See [Authentication](/api-reference/authentication) for key types.
+
+## When to use which mode
+
+| You want to... | Use |
+|---|---|
+| Record usage that just happened (normal flow) | Neither flag — server time is used |
+| Correct an event that happened yesterday or earlier today, including billing impact | `trusted_client_clock` |
+| Import months of historical usage for analytics, without re-billing customers | `backfill` |
+
+## `trusted_client_clock`
+
+When `true`, Schematic uses the `sent_at` you provide as the event's effective timestamp (`captured_at`) instead of server receipt time.
+
+**Bounds on `sent_at`:**
+- No more than 5 minutes in the future
+- No more than **34 days** in the past
+
+The 34-day past bound sits one day inside Stripe's meter-event 35-day cap, to absorb wall-clock skew between Schematic and Stripe. For older events, use `backfill`.
+
+All normal processing still happens — billing impact, webhooks, and activity updates fire as usual — just anchored to the logical timestamp instead of the receipt time. Feature usage counters only count the event toward periods that the logical timestamp falls within, so an event timestamped yesterday won't show up in today's daily counter.
+
+```json
+{
+  "api_key": "sch_secret_...",
+  "type": "track",
+  "sent_at": "2026-05-17T14:30:00Z",
+  "trusted_client_clock": true,
+  "body": {
+    "event": "api-call",
+    "company": { "your-company-key": "value" },
+    "quantity": 50
+  }
+}
+```
+
+## `backfill`
+
+`backfill: true` implies `trusted_client_clock` — `sent_at` is the effective timestamp — but **all billing side effects are skipped**. Use this when you want historical usage to appear in analytics without re-running billing.
+
+**Bounds on `sent_at`:**
+- No more than 5 minutes in the future
+- No more than **365 days** in the past
+
+**Skipped:**
+- Billing impact (credit consumption, Stripe meter reporting, auto-topup)
+- Webhooks
+- `last_seen_at` bumps on companies and users (historical events shouldn't shift present-time activity)
+
+**Still happens:**
+- The event is stored at its logical timestamp and shows up in analytics there.
+- Feature usage counters reflect the event for periods the logical timestamp falls within.
+- Companies and users referenced by the event are still created or linked from the event keys — their `last_seen_at` just isn't touched.
+
+```json
+{
+  "api_key": "sch_secret_...",
+  "type": "track",
+  "sent_at": "2025-10-15T09:00:00Z",
+  "backfill": true,
+  "body": {
+    "event": "api-call",
+    "company": { "your-company-key": "value" },
+    "quantity": 1000
+  }
+}
+```
+
+## Behavior matrix
+
+| Behavior | Normal | `trusted_client_clock` | `backfill` |
+|---|---|---|---|
+| Effective `captured_at` | server time | `sent_at` | `sent_at` |
+| Billing impact | Yes (current time) | Yes (logical time) | No |
+| Webhooks | Yes | Yes | No |
+| Feature usage counters | Yes (all periods) | Period-filtered | Period-filtered |
+| Company/user create or link | Yes | Yes | Yes |
+| Company/user `last_seen_at` bump | Yes | Yes | No |
+
+## SDK example
+
+```ts
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_SECRET_KEY });
+
+// Usage correction: an api-call from yesterday that we missed
+await client.track({
+  event: "api-call",
+  company: { "your-company-key": "value" },
+  quantity: 50,
+  sentAt: new Date("2026-05-17T14:30:00Z"),
+  trustedClientClock: true,
+});
+
+// Historical backfill: import a month-old event for analytics only
+await client.track({
+  event: "api-call",
+  company: { "your-company-key": "value" },
+  quantity: 1000,
+  sentAt: new Date("2025-10-15T09:00:00Z"),
+  backfill: true,
+});
+```
+
+## Retention
+
+Events are retained for 365 days, measured from the event's effective `captured_at`. A `backfill` submitted near the 365-day past bound therefore lands with very little remaining retention — by design. Aggregated feature usage is preserved separately on the same logical-period anchor, so usage charts and entitlement counters stay intact even after the underlying event expires.
+
+## Validation errors
+
+| Condition | Error |
+|---|---|
+| `trusted_client_clock` or `backfill` with a publishable key | `trusted_client_clock and backfill require a secret API key` |
+| `trusted_client_clock` or `backfill` without `sent_at` | `sent_at is required when trusted_client_clock or backfill is true` |
+| `sent_at` more than 5 minutes in the future | `sent_at cannot be more than 5 minutes in the future` |
+| `trusted_client_clock` with `sent_at` more than 34 days in the past | `sent_at cannot be more than 34 days in the past for trusted_client_clock; for older events use backfill (analytics-only, no billing side effects)` |
+| `backfill` with `sent_at` more than 365 days in the past | `sent_at cannot be more than 365 days in the past` |
+
+## Related
+
+- [Creating a metered feature](/playbooks/metering)
+- [Negative quantities (usage adjustments)](/billing/usage-based-billing#negative-quantities-usage-adjustments)
+- [The Event object](/api-reference/events/event-object)

--- a/fern/docs/pages/playbooks/metering.mdx
+++ b/fern/docs/pages/playbooks/metering.mdx
@@ -20,6 +20,8 @@ There are two types of metered features in Schematic - trait-based and event-bas
 
 Event-based features also support **negative quantities** for adjustments such as refunds or corrections. Negative quantity events must be submitted using a secret API key. See [Negative Quantities](/billing/usage-based-billing#negative-quantities-usage-adjustments) for details.
 
+For importing historical usage or correcting events with stale timestamps, see [Backfills and usage corrections](/playbooks/backfill-and-corrections).
+
 To safely retry network calls without double-counting usage, you can submit an optional `idempotency_key` with each event. Duplicate events with the same key — scoped to the same environment and event type — are dropped for 24 hours. See the [Event object](/api-documentation/event#idempotency_key) for details.
 
 <Info>


### PR DESCRIPTION
Documents the new `trusted_client_clock` and `backfill` event payload flags shipped in schematic-api PR #4484 (SCHY-233).