### PR TITLE
docs: add WorkOS integration implementation guides

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -248,6 +248,12 @@ navigation:
           - page: Clerk Integration
             path: ./docs/pages/integrations/clerk.mdx
             icon: "fa-solid fa-lock-open"
+          - page: WorkOS Integration
+            path: ./docs/pages/integrations/workos.mdx
+            icon: "fa-solid fa-key"
+          - page: Auth0 Integration
+            path: ./docs/pages/integrations/auth0.mdx
+            icon: "fa-solid fa-user-lock"
           - page: Salesforce Integration
             path: ./docs/pages/integrations/salesforce.mdx
             icon: "fa-brands fa-salesforce"

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -251,9 +251,9 @@ navigation:
           - page: WorkOS Integration
             path: ./docs/pages/integrations/workos.mdx
             icon: "fa-solid fa-key"
-          - page: Auth0 Integration
-            path: ./docs/pages/integrations/auth0.mdx
-            icon: "fa-solid fa-user-lock"
+          # - page: Auth0 Integration
+          #   path: ./docs/pages/integrations/auth0.mdx
+          #   icon: "fa-solid fa-user-lock"
           - page: Salesforce Integration
             path: ./docs/pages/integrations/salesforce.mdx
             icon: "fa-brands fa-salesforce"

--- a/fern/docs/pages/integrations/auth0.mdx
+++ b/fern/docs/pages/integrations/auth0.mdx
@@ -1,0 +1,284 @@
+---
+title: Auth0 Integration
+
+slug: integrations/auth0
+---
+
+<Note>
+This is an **implementation guide**, not a native integration. Schematic does not
+offer a turnkey Auth0 connector. Auth0 still works with Schematic today through
+Schematic's [keys system](/developer_resources/key_management): you bring the
+Auth0 organization and user IDs as keys, and everything else behaves normally.
+This page describes exactly what you would set up.
+</Note>
+
+[Auth0](https://auth0.com) is an authentication and identity provider. Because
+Schematic identifies companies and users by your own `keys` rather than by
+Schematic-generated IDs, you can use Auth0 as the source of truth for identity
+and layer Schematic entitlements, feature flags, and embeddable components on top
+of it without storing any Schematic IDs.
+
+There are three pieces to a complete Auth0 implementation:
+
+1. **Create companies and users in Schematic keyed by their Auth0 IDs.** This
+happens either from an Auth0 Post-Login Action or inline in your own
+signup/provisioning flow. From then on you address those entities by their Auth0
+IDs in every API/SDK call and usage event, so you never need to store or look up
+a Schematic ID.
+2. **A one-time backfill** from Auth0 into Schematic when you deploy, so existing
+organizations and users don't have gaps.
+3. **Ongoing sync** so Schematic stays accurate as profiles change and users come
+and go. With Auth0 this mostly comes for free from the Post-Login Action; deletes
+need a little extra handling.
+
+## How Auth0 maps to Schematic
+
+| Auth0 object | Schematic entity | Recommended keys |
+|---|---|---|
+| Organization (`org_...`) | Company | `auth0_organization_id` |
+| User (`auth0\|...`, `google-oauth2\|...`) | User | `auth0_user_id`, `email` |
+| Organization member | Sets the user's parent company | n/a |
+
+An Auth0 Organization becomes a Schematic **company**, an Auth0 User becomes a
+Schematic **user**, and an Auth0 organization membership tells you which company
+a user belongs to. The Auth0 user ID (the `sub` claim) and organization ID are
+stable and unique, which makes them good primary `keys`. Review
+[Key Management](/developer_resources/key_management) for background on how
+`keys` work.
+
+<Info>
+Auth0 Organizations is an opt-in feature. If you don't use it, your "company" in
+Schematic likely corresponds to a tenant identifier you keep in
+`app_metadata` instead. Map that identifier to the company key wherever this
+guide uses `auth0_organization_id`; everything else is the same.
+</Info>
+
+<Info>
+The key names `auth0_organization_id`, `auth0_user_id`, and `email` used
+throughout this guide are recommendations, not requirements. Schematic key names
+are arbitrary strings, so you can choose names that fit your own conventions.
+What matters is that you pick a name for each and use it consistently in every
+call. Storing more than one key per entity is encouraged: Schematic resolves
+between keys, so a user keyed by both `auth0_user_id` and `email` can be
+addressed by whichever value you have on hand in a given context.
+</Info>
+
+## 1. Create companies and users keyed by Auth0 IDs
+
+When an organization or user is created in Auth0, upsert the matching entity into
+Schematic and store the Auth0 IDs as `keys`. Because Schematic upserts are
+idempotent, the same call safely creates the entity the first time and updates it
+on every call after that.
+
+```ts
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
+
+// An organization signs up
+await client.companies.upsertCompany({
+  keys: { auth0_organization_id: "org_EXAMPLE0123456789" },
+  name: "Acme Inc.",
+});
+
+// A user signs up and belongs to that organization
+await client.companies.upsertUser({
+  keys: {
+    auth0_user_id: "auth0|EXAMPLE0123456789",
+    email: "marcelina.davis@example.com",
+  },
+  name: "Marcelina Davis",
+  // `company` accepts the parent company's keys, so the user is
+  // associated with the right Schematic company
+  company: { auth0_organization_id: "org_EXAMPLE0123456789" },
+});
+```
+
+### Where to make these calls
+
+Unlike some providers, Auth0 Actions can make external HTTP calls, so the
+idiomatic place to do this is a **Post-Login Action**. The action runs on every
+login, which means it also keeps names, emails, and organization membership fresh
+over time without any separate update mechanism. You can also do the upserts
+inline in your own provisioning flow if you prefer; use whichever fits, or both.
+
+- **Post-Login Action (recommended).** Add a Post-Login Action, install the
+Schematic SDK as a dependency, and store your Schematic API key as an Action
+Secret. The action is blocking, so wrap the calls in a `try/catch` and keep them
+fast: a Schematic hiccup should never block a user's login.
+
+  ```ts
+  exports.onExecutePostLogin = async (event, api) => {
+    const { SchematicClient } = require("@schematichq/schematic-typescript-node");
+    const client = new SchematicClient({
+      apiKey: event.secrets.SCHEMATIC_API_KEY,
+    });
+
+    try {
+      if (event.organization) {
+        await client.companies.upsertCompany({
+          keys: { auth0_organization_id: event.organization.id },
+          name: event.organization.display_name ?? event.organization.name,
+        });
+      }
+
+      await client.companies.upsertUser({
+        keys: {
+          auth0_user_id: event.user.user_id,
+          email: event.user.email,
+        },
+        name: event.user.name,
+        ...(event.organization
+          ? { company: { auth0_organization_id: event.organization.id } }
+          : {}),
+      });
+    } catch (err) {
+      // Never block login on a Schematic hiccup
+      console.error("Schematic sync failed", err);
+    }
+  };
+  ```
+
+- **In your own signup/provisioning flow.** Wherever your application already
+creates the organization or user, add the same Schematic upserts immediately
+after. This is something you wire into your own code, and it is a good choice
+when you want the entity to exist in Schematic before the user's first request
+completes.
+
+There is also a **Post-User-Registration Action**, but it only fires for
+database connections and has no organization context, so it covers fewer cases
+than Post-Login. Post-Login on every login is the most reliable single hook.
+
+### Use the Auth0 IDs in every subsequent call
+
+Once the Auth0 IDs are stored as `keys`, you address companies and users by those
+same IDs everywhere. You never store a Schematic ID.
+
+Checking a feature flag or entitlement:
+
+```ts
+const isOn = await client.checkFlag(
+  {
+    company: { auth0_organization_id: "org_EXAMPLE0123456789" },
+    user: { auth0_user_id: "auth0|EXAMPLE0123456789" },
+  },
+  "your-feature-flag",
+);
+```
+
+Tracking usage of a metered feature:
+
+```ts
+client.track({
+  event: "api-request",
+  company: { auth0_organization_id: "org_EXAMPLE0123456789" },
+  user: { auth0_user_id: "auth0|EXAMPLE0123456789" },
+});
+```
+
+The same Auth0 IDs work for identify events, trait updates, usage retrieval, and
+[embeddable components](/components/overview), which become aware of the
+logged-in Auth0 user automatically.
+
+## 2. One-time backfill when you deploy
+
+The Post-Login Action only reaches users the next time they log in, so existing
+organizations and users have gaps until then. To close them immediately, run a
+one-time backfill with the Auth0 Management API.
+
+The cleanest path iterates organizations and their members. Auth0's organization
+endpoints use checkpoint pagination: pass `take` and follow the `next` cursor
+until it is empty. Member listing supports more than 1000 results this way, which
+the `GET /api/v2/users` endpoint does not.
+
+```ts
+import { ManagementClient } from "auth0";
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const auth0 = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+});
+const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
+
+let from: string | undefined;
+do {
+  const { data } = await auth0.organizations.getAll({ take: 100, from });
+
+  for (const org of data.organizations) {
+    await client.companies.upsertCompany({
+      keys: { auth0_organization_id: org.id },
+      name: org.display_name ?? org.name,
+    });
+
+    // Members of this organization -> Schematic users
+    let memberFrom: string | undefined;
+    do {
+      const members = await auth0.organizations.getMembers({
+        id: org.id,
+        take: 100,
+        from: memberFrom,
+      });
+      for (const member of members.data.members) {
+        await client.companies.upsertUser({
+          keys: { auth0_user_id: member.user_id, email: member.email },
+          name: member.name,
+          company: { auth0_organization_id: org.id },
+        });
+      }
+      memberFrom = members.data.next;
+    } while (memberFrom);
+  }
+
+  from = data.next;
+} while (from);
+```
+
+<Info>
+For users who are not members of any organization, or tenants that don't use
+Auth0 Organizations, use Auth0's bulk **User Export job** rather than paging
+`GET /api/v2/users`, which never returns more than 1000 users. Upsert each
+exported user the same way, mapping your own tenant identifier to the company
+key. Because upserts are idempotent and matched on `keys`, the backfill is safe
+to re-run.
+</Info>
+
+## 3. Keep Schematic in sync over time
+
+Auth0 does not emit clean entity webhooks the way some providers do, so the sync
+strategy is different from a webhook-per-event model.
+
+- **Profile and membership changes** are handled by the Post-Login Action from
+section 1. Because it upserts on every login, names, emails, and organization
+membership stay current without any extra wiring. This is enough for most teams.
+- **Deletions** are the one case the Post-Login Action cannot cover, since a
+deleted user never logs in again. Handle deletes where you already delete the
+Auth0 user: in the admin or account-management flow that calls the Auth0
+Management API to remove the user or organization, call Schematic in the same
+place.
+
+  ```ts
+  await schematic.companies.deleteUserByKeys({
+    keys: { auth0_user_id: "auth0|EXAMPLE0123456789" },
+  });
+
+  await schematic.companies.deleteCompanyByKeys({
+    keys: { auth0_organization_id: "org_EXAMPLE0123456789" },
+  });
+  ```
+
+- **Deletions initiated outside your app** (for example directly in the Auth0
+dashboard) won't hit that code path. If that happens in your environment,
+configure an Auth0 **Log Stream** with a custom webhook and react to the
+deletion log events. Log Streams deliver log records rather than entity objects
+and are not meant for real-time decisions, so treat this as an asynchronous
+cleanup path and key the Schematic delete off the user or organization ID in the
+log event.
+
+<Warning>
+Keep the Post-Login Action fast and wrapped in `try/catch`. It is blocking, so an
+unhandled error or a slow call there degrades the login experience for every
+user. Logging failures and moving on keeps authentication healthy while you
+investigate.
+</Warning>

--- a/fern/docs/pages/integrations/workos.mdx
+++ b/fern/docs/pages/integrations/workos.mdx
@@ -47,6 +47,16 @@ them good primary `keys`. Review
 `keys` work.
 
 <Info>
+This guide assumes you use WorkOS **User Management** (AuthKit): durable
+`user_...` users, `org_...` organizations, and `om_...` memberships. If you use
+WorkOS only for standalone SSO, each login gives you a profile rather than a
+persistent User Management user, so the user and membership webhooks and list
+endpoints below do not apply. In that case, upsert the company and user from your
+own callback using whatever stable identifiers you keep, and the rest of this
+guide works the same.
+</Info>
+
+<Info>
 The key names `workos_organization_id`, `workos_user_id`, and `email` used
 throughout this guide are recommendations, not requirements. Schematic key names
 are arbitrary strings, so you can choose names that fit your own conventions.
@@ -91,6 +101,16 @@ await client.companies.upsertUser({
 });
 ```
 
+<Info>
+This guide associates each user with a single company through the `company`
+field, which fits the common case of one user belonging to one organization.
+WorkOS users can belong to **multiple** organizations. If yours do, use the
+plural `companies` field instead and pass the user's full set of organizations.
+Schematic treats `companies` as the exhaustive list, so it adds new memberships
+and removes any you leave out. The webhook handler in section 3 uses this
+exhaustive pattern.
+</Info>
+
 ### Where to make these calls
 
 WorkOS does not run arbitrary custom code for you after a signup. WorkOS Actions
@@ -134,7 +154,7 @@ const isOn = await client.checkFlag(
 Tracking usage of a metered feature:
 
 ```ts
-client.track({
+await client.track({
   event: "api-request",
   company: { workos_organization_id: "org_EXAMPLE0123456789" },
   user: { workos_user_id: "user_EXAMPLE0123456789" },
@@ -163,10 +183,12 @@ const workos = new WorkOS(process.env.WORKOS_API_KEY);
 const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
 
 // 1. Backfill organizations -> Schematic companies
+const organizationIds: string[] = [];
 let after: string | undefined;
 do {
   const page = await workos.organizations.listOrganizations({ limit: 100, after });
   for (const org of page.data) {
+    organizationIds.push(org.id);
     await client.companies.upsertCompany({
       keys: { workos_organization_id: org.id },
       name: org.name,
@@ -189,22 +211,26 @@ do {
 } while (after);
 
 // 3. Backfill memberships so each user is tied to the right company.
-//    List memberships per organization, iterating the organizations above.
-after = undefined;
-do {
-  const page = await workos.userManagement.listOrganizationMemberships({
-    organizationId: "org_EXAMPLE0123456789",
-    limit: 100,
-    after,
-  });
-  for (const membership of page.data) {
-    await client.companies.upsertUser({
-      keys: { workos_user_id: membership.userId },
-      company: { workos_organization_id: membership.organizationId },
+//    Page through every organization collected in step 1. Because `company`
+//    adds the user to that company without removing others, a user who belongs
+//    to multiple organizations accumulates all of them across the loop.
+for (const organizationId of organizationIds) {
+  after = undefined;
+  do {
+    const page = await workos.userManagement.listOrganizationMemberships({
+      organizationId,
+      limit: 100,
+      after,
     });
-  }
-  after = page.listMetadata.after ?? undefined;
-} while (after);
+    for (const membership of page.data) {
+      await client.companies.upsertUser({
+        keys: { workos_user_id: membership.userId },
+        company: { workos_organization_id: membership.organizationId },
+      });
+    }
+    after = page.listMetadata.after ?? undefined;
+  } while (after);
+}
 ```
 
 <Info>
@@ -249,7 +275,10 @@ const app = express();
 const workos = new WorkOS(process.env.WORKOS_API_KEY);
 const schematic = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
 
-app.post("/webhooks/workos", express.json(), async (req, res) => {
+// Use express.raw, not express.json. constructEvent verifies the signature
+// against the exact bytes WorkOS sent, so it needs the raw body. Handing it a
+// parsed-then-re-serialized object can fail verification if the JSON differs.
+app.post("/webhooks/workos", express.raw({ type: "application/json" }), async (req, res) => {
   let event;
   try {
     event = await workos.webhooks.constructEvent({
@@ -261,54 +290,73 @@ app.post("/webhooks/workos", express.json(), async (req, res) => {
     return res.status(400).send("Invalid signature");
   }
 
-  // Acknowledge quickly, then process
-  res.status(200).send("OK");
+  // The event type is on `event.event`, not `event.type`.
+  const { event: type, data } = event;
+  try {
+    switch (type) {
+      case "organization.created":
+      case "organization.updated":
+        await schematic.companies.upsertCompany({
+          keys: { workos_organization_id: data.id },
+          name: data.name,
+        });
+        break;
 
-  const { type, data } = event;
-  switch (type) {
-    case "organization.created":
-    case "organization.updated":
-      await schematic.companies.upsertCompany({
-        keys: { workos_organization_id: data.id },
-        name: data.name,
-      });
-      break;
+      case "organization.deleted":
+        await schematic.companies.deleteCompanyByKeys({
+          keys: { workos_organization_id: data.id },
+        });
+        break;
 
-    case "organization.deleted":
-      await schematic.companies.deleteCompanyByKeys({
-        keys: { workos_organization_id: data.id },
-      });
-      break;
+      case "user.created":
+      case "user.updated":
+        await schematic.companies.upsertUser({
+          keys: { workos_user_id: data.id, email: data.email },
+          name: `${data.firstName ?? ""} ${data.lastName ?? ""}`.trim(),
+        });
+        break;
 
-    case "user.created":
-    case "user.updated":
-      await schematic.companies.upsertUser({
-        keys: { workos_user_id: data.id, email: data.email },
-        name: `${data.firstName ?? ""} ${data.lastName ?? ""}`.trim(),
-      });
-      break;
+      case "user.deleted":
+        await schematic.companies.deleteUserByKeys({
+          keys: { workos_user_id: data.id },
+        });
+        break;
 
-    case "user.deleted":
-      await schematic.companies.deleteUserByKeys({
-        keys: { workos_user_id: data.id },
-      });
-      break;
-
-    case "organization_membership.created":
-    case "organization_membership.updated":
-      // Re-associate the user with the correct company
-      await schematic.companies.upsertUser({
-        keys: { workos_user_id: data.userId },
-        company: { workos_organization_id: data.organizationId },
-      });
-      break;
+      case "organization_membership.created":
+      case "organization_membership.updated":
+      case "organization_membership.deleted": {
+        // Re-derive the user's current organizations and write them as the
+        // exhaustive `companies` list. This reflects both additions and
+        // removals: a deleted membership drops that company, and a user left
+        // with none is cleared (companies: []).
+        const memberships = await workos.userManagement.listOrganizationMemberships({
+          userId: data.userId,
+          limit: 100,
+        });
+        await schematic.companies.upsertUser({
+          keys: { workos_user_id: data.userId },
+          companies: memberships.data.map((m) => ({
+            workos_organization_id: m.organizationId,
+          })),
+        });
+        break;
+      }
+    }
+  } catch (err) {
+    // Return a non-2xx so WorkOS retries the delivery.
+    console.error("Schematic sync failed", err);
+    return res.status(500).send("Sync failed");
   }
+
+  res.status(200).send("OK");
 });
 ```
 
 <Warning>
-Respond to the webhook with a `2xx` immediately and do the Schematic work after
-(or on a queue). WorkOS retries on non-`2xx` responses or timeouts, so keep the
-handler fast and idempotent. Logging the WorkOS event `id` lets you safely skip
-duplicates.
+WorkOS retries on non-`2xx` responses or timeouts. The handler above does the
+Schematic work first and returns `200` only once it succeeds, so a transient
+failure returns `500` and WorkOS retries it. Keep the work fast and idempotent.
+If processing is heavy, enqueue the verified event, return `2xx` immediately, and
+do the Schematic work from the queue with its own retries instead. Logging the
+WorkOS event `id` lets you safely skip duplicates.
 </Warning>

--- a/fern/docs/pages/integrations/workos.mdx
+++ b/fern/docs/pages/integrations/workos.mdx
@@ -1,0 +1,314 @@
+---
+title: WorkOS Integration
+
+slug: integrations/workos
+---
+
+<Note>
+This is an **implementation guide**, not a native integration. Schematic does not
+offer a turnkey WorkOS connector. WorkOS still works with Schematic today through
+Schematic's [keys system](/developer_resources/key_management): you bring the
+WorkOS organization and user IDs as keys, and everything else behaves normally.
+This page describes exactly what you would set up.
+</Note>
+
+[WorkOS](https://workos.com) is an authentication and directory provider. Because
+Schematic identifies companies and users by your own `keys` rather than by
+Schematic-generated IDs, you can use WorkOS as the source of truth for identity
+and layer Schematic entitlements, feature flags, and embeddable components on top
+of it without storing any Schematic IDs.
+
+There are three pieces to a complete WorkOS implementation:
+
+1. **Create companies and users in Schematic keyed by their WorkOS IDs.** This
+happens either inline in your own signup/provisioning flow or from WorkOS
+webhooks. From then on you address those entities by their WorkOS IDs in every
+API/SDK call and usage event, so you never need to store or look up a Schematic
+ID.
+2. **A one-time backfill** from WorkOS into Schematic when you deploy, so
+existing organizations and users don't have gaps.
+3. **Optionally (recommended), WorkOS webhooks** to keep Schematic in sync as
+your user base changes over time. Not every WorkOS customer needs this; whether
+it's worth it depends on how much your organizations and users churn.
+
+## How WorkOS maps to Schematic
+
+| WorkOS object | Schematic entity | Recommended keys |
+|---|---|---|
+| Organization (`org_...`) | Company | `workos_organization_id` |
+| User (`user_...`) | User | `workos_user_id`, `email` |
+| Organization Membership (`om_...`) | Sets the user's parent company | n/a |
+
+A WorkOS Organization becomes a Schematic **company**, a WorkOS User becomes a
+Schematic **user**, and a WorkOS Organization Membership tells you which company
+a user belongs to. The WorkOS IDs are stable and globally unique, which makes
+them good primary `keys`. Review
+[Key Management](/developer_resources/key_management) for background on how
+`keys` work.
+
+<Info>
+The key names `workos_organization_id`, `workos_user_id`, and `email` used
+throughout this guide are recommendations, not requirements. Schematic key names
+are arbitrary strings, so you can choose names that fit your own conventions.
+What matters is that you pick a name for each and use it consistently in every
+call. Storing more than one key per entity is encouraged: Schematic resolves
+between keys, so a user keyed by both `workos_user_id` and `email` can be
+addressed by whichever value you have on hand in a given context.
+</Info>
+
+## 1. Create companies and users keyed by WorkOS IDs
+
+When an organization or user is created in WorkOS, upsert the matching entity
+into Schematic and store the WorkOS IDs as `keys`. Because Schematic upserts are
+idempotent, the same call safely creates the entity the first time and updates
+it on every call after that.
+
+```ts
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
+
+// An organization signs up
+await client.companies.upsertCompany({
+  keys: { workos_organization_id: "org_EXAMPLE0123456789" },
+  name: "Acme Inc.",
+  traits: {
+    // Optional: carry over WorkOS context you want to target on
+    workosExternalId: "EXAMPLE_EXTERNAL_ID",
+  },
+});
+
+// A user signs up and joins that organization
+await client.companies.upsertUser({
+  keys: {
+    workos_user_id: "user_EXAMPLE0123456789",
+    email: "marcelina.davis@example.com",
+  },
+  name: "Marcelina Davis",
+  // `company` accepts the parent company's keys, so the user is
+  // associated with the right Schematic company
+  company: { workos_organization_id: "org_EXAMPLE0123456789" },
+});
+```
+
+### Where to make these calls
+
+WorkOS does not run arbitrary custom code for you after a signup. WorkOS Actions
+are synchronous allow/deny gates for authentication and registration, so they
+are the wrong tool for syncing to an external system. That leaves two practical
+places to make the Schematic upserts, and you can use either or both:
+
+- **In your own signup/provisioning flow.** Wherever your application already
+creates the organization or user, for example your AuthKit callback handler or
+the code that provisions a tenant in your database, add the Schematic upsert
+immediately after. This is something you wire into your own code. It has the
+lowest latency and keeps creation in your control.
+- **From WorkOS webhooks.** Subscribe to `organization.created`,
+`user.created`, and `organization_membership.created` and do the upserts in the
+webhook handler. This is the same handler used for ongoing sync in section 3,
+so if you handle those events, signup creation is already covered and you may
+not need any inline calls at all.
+
+Many teams route everything through webhooks so there is a single sync path for
+creation, updates, and deletes. Wiring the upserts into your provisioning flow
+is a good choice when you want the company or user to exist in Schematic before
+the user's first request completes.
+
+### Use the WorkOS IDs in every subsequent call
+
+Once the WorkOS IDs are stored as `keys`, you address companies and users by
+those same IDs everywhere. You never store a Schematic ID.
+
+Checking a feature flag or entitlement:
+
+```ts
+const isOn = await client.checkFlag(
+  {
+    company: { workos_organization_id: "org_EXAMPLE0123456789" },
+    user: { workos_user_id: "user_EXAMPLE0123456789" },
+  },
+  "your-feature-flag",
+);
+```
+
+Tracking usage of a metered feature:
+
+```ts
+client.track({
+  event: "api-request",
+  company: { workos_organization_id: "org_EXAMPLE0123456789" },
+  user: { workos_user_id: "user_EXAMPLE0123456789" },
+});
+```
+
+The same WorkOS IDs work for identify events, trait updates, usage retrieval,
+and [embeddable components](/components/overview), which become aware of the
+logged-in WorkOS user automatically.
+
+## 2. One-time backfill when you deploy
+
+Creating entities going forward only covers organizations and users created
+after you ship. To avoid gaps for everyone who already exists in WorkOS, run a
+one-time backfill that pages through WorkOS and upserts each organization, user,
+and membership into Schematic using the same `keys`.
+
+WorkOS list endpoints are cursor-paginated: pass `limit` (up to 100) and follow
+the `after` cursor from `listMetadata` until it is empty.
+
+```ts
+import { WorkOS } from "@workos-inc/node";
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const workos = new WorkOS(process.env.WORKOS_API_KEY);
+const client = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
+
+// 1. Backfill organizations -> Schematic companies
+let after: string | undefined;
+do {
+  const page = await workos.organizations.listOrganizations({ limit: 100, after });
+  for (const org of page.data) {
+    await client.companies.upsertCompany({
+      keys: { workos_organization_id: org.id },
+      name: org.name,
+    });
+  }
+  after = page.listMetadata.after ?? undefined;
+} while (after);
+
+// 2. Backfill users -> Schematic users
+after = undefined;
+do {
+  const page = await workos.userManagement.listUsers({ limit: 100, after });
+  for (const user of page.data) {
+    await client.companies.upsertUser({
+      keys: { workos_user_id: user.id, email: user.email },
+      name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim(),
+    });
+  }
+  after = page.listMetadata.after ?? undefined;
+} while (after);
+
+// 3. Backfill memberships so each user is tied to the right company.
+//    List memberships per organization, iterating the organizations above.
+after = undefined;
+do {
+  const page = await workos.userManagement.listOrganizationMemberships({
+    organizationId: "org_EXAMPLE0123456789",
+    limit: 100,
+    after,
+  });
+  for (const membership of page.data) {
+    await client.companies.upsertUser({
+      keys: { workos_user_id: membership.userId },
+      company: { workos_organization_id: membership.organizationId },
+    });
+  }
+  after = page.listMetadata.after ?? undefined;
+} while (after);
+```
+
+<Info>
+Because upserts are idempotent and matched on `keys`, the backfill is safe to
+re-run. If a company or user already exists with a matching
+`workos_organization_id` or `workos_user_id`, the record is updated rather than
+duplicated.
+</Info>
+
+## 3. (Recommended) Keep Schematic in sync with WorkOS webhooks
+
+The backfill is a point-in-time snapshot, and creating entities only covers new
+ones. WorkOS webhooks close the gap for everything that changes afterward:
+profile and name updates, users moving between organizations, and deletions.
+Not every WorkOS customer wires this up. If your organizations and users rarely
+change, the backfill plus signup-time creation may be enough. If your user base
+churns meaningfully, webhooks keep Schematic accurate without manual cleanup.
+
+### Subscribe to the relevant events
+
+In the WorkOS Dashboard, create a webhook endpoint pointing at a public HTTPS
+URL in your application and subscribe to the events you care about:
+
+- `user.created`, `user.updated`, `user.deleted`
+- `organization.created`, `organization.updated`, `organization.deleted`
+- `organization_membership.created`, `organization_membership.updated`, `organization_membership.deleted`
+
+### Verify and handle each event
+
+WorkOS signs every webhook request with a `WorkOS-Signature` header. The WorkOS
+Node SDK verifies the signature and constructs the event for you with
+`workos.webhooks.constructEvent`. Always verify before acting on a payload, then
+translate the WorkOS event into the matching Schematic upsert or delete keyed by
+the WorkOS ID.
+
+```ts
+import { WorkOS } from "@workos-inc/node";
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+import express from "express";
+
+const app = express();
+const workos = new WorkOS(process.env.WORKOS_API_KEY);
+const schematic = new SchematicClient({ apiKey: process.env.SCHEMATIC_API_KEY });
+
+app.post("/webhooks/workos", express.json(), async (req, res) => {
+  let event;
+  try {
+    event = await workos.webhooks.constructEvent({
+      payload: req.body,
+      sigHeader: req.headers["workos-signature"],
+      secret: process.env.WORKOS_WEBHOOK_SECRET,
+    });
+  } catch {
+    return res.status(400).send("Invalid signature");
+  }
+
+  // Acknowledge quickly, then process
+  res.status(200).send("OK");
+
+  const { type, data } = event;
+  switch (type) {
+    case "organization.created":
+    case "organization.updated":
+      await schematic.companies.upsertCompany({
+        keys: { workos_organization_id: data.id },
+        name: data.name,
+      });
+      break;
+
+    case "organization.deleted":
+      await schematic.companies.deleteCompanyByKeys({
+        keys: { workos_organization_id: data.id },
+      });
+      break;
+
+    case "user.created":
+    case "user.updated":
+      await schematic.companies.upsertUser({
+        keys: { workos_user_id: data.id, email: data.email },
+        name: `${data.firstName ?? ""} ${data.lastName ?? ""}`.trim(),
+      });
+      break;
+
+    case "user.deleted":
+      await schematic.companies.deleteUserByKeys({
+        keys: { workos_user_id: data.id },
+      });
+      break;
+
+    case "organization_membership.created":
+    case "organization_membership.updated":
+      // Re-associate the user with the correct company
+      await schematic.companies.upsertUser({
+        keys: { workos_user_id: data.userId },
+        company: { workos_organization_id: data.organizationId },
+      });
+      break;
+  }
+});
+```
+
+<Warning>
+Respond to the webhook with a `2xx` immediately and do the Schematic work after
+(or on a queue). WorkOS retries on non-`2xx` responses or timeouts, so keep the
+handler fast and idempotent. Logging the WorkOS event `id` lets you safely skip
+duplicates.
+</Warning>


### PR DESCRIPTION
## Summary

NOTE: auth0 is commented out until I can review it, but wanted to get WorkOS out the door

Adds two new pages to the Integrations section as **implementation guides** (not native integrations): there is no turnkey connector for either provider, so these document how customers wire WorkOS / Auth0 into Schematic today via the keys system. Neither page commits to a future native integration.

- **WorkOS** (`integrations/workos`): create companies/users keyed by WorkOS org/user IDs (inline in the signup/provisioning flow or via WorkOS webhooks), one-time Management-API backfill, and ongoing webhook sync with signature verification.
- **Auth0** (`integrations/auth0`): same shape, adapted to Auth0's mechanisms — Post-Login Action (Auth0 Actions can make external calls), Management API checkpoint-paginated backfill, and sync that rides on the Post-Login Action with delete handling. Notes that Auth0 Organizations is opt-in.

Both use the Schematic Node SDK, store the provider IDs plus `email` as keys (multiple keys encouraged), frame key names as recommendations, and use obvious placeholder IDs.

## Changes

- `fern/docs/pages/integrations/workos.mdx` (new)
- `fern/docs/pages/integrations/auth0.mdx` (new)
- `fern/docs.yml` — two nav entries under Integrations, after Clerk

## Validation

`fern check` passes with 0 errors.

## Reviewer note

The Auth0 backfill snippet uses `node-auth0` ManagementClient method/response shapes. The REST checkpoint-pagination contract is verified against Auth0 docs, but exact SDK return shapes vary by major version and may need a tweak against a pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)