### PR TITLE
docs: fix 10 broken internal links in docs/pages

### DIFF
--- a/fern/docs/pages/billing/credit-burndown.mdx
+++ b/fern/docs/pages/billing/credit-burndown.mdx
@@ -221,7 +221,7 @@ When working with credit burndown models, you can retrieve credit balance and us
 
 ### List Company Credit Grants
 
-To see all credit grants associated with a specific company, use the [List Company Credit Grants](/api-reference/billing-credits/list-company-credit-grants) endpoint. This endpoint returns detailed information about each credit grant, including grant type (plan, purchased, promotional), quantity, remaining balance, and expiration dates, helping you understand the composition of a customer's credit balance.
+To see all credit grants associated with a specific company, use the [List Company Credit Grants](/api-reference/billing-credits/list-company-grants) endpoint. This endpoint returns detailed information about each credit grant, including grant type (plan, purchased, promotional), quantity, remaining balance, and expiration dates, helping you understand the composition of a customer's credit balance.
 
 ### Grant Billing Credits to Company
 

--- a/fern/docs/pages/billing/usage-based-billing.mdx
+++ b/fern/docs/pages/billing/usage-based-billing.mdx
@@ -8,7 +8,7 @@ Schematic enables you to implement usage-based billing models quickly, and enfor
 
 For instance if you have a pay in advance model, when a customer reaches the credit limit, you can prevent them from using more.
 
-While base charges (e.g. a subscription fee) are defined at the plan level, as described [here](/catalog/create-catalog#creating-a-plan-or-add-on), usage-based billing is defined at the individual entitlement level.
+While base charges (e.g. a subscription fee) are defined at the plan level, as described [here](/catalog/plans#create-a-plan), usage-based billing is defined at the individual entitlement level.
 
 ![Pay as you go](../../assets/images/billing/ubp-entitlement-configuration-paygo.png)
 

--- a/fern/docs/pages/catalog/add-ons.mdx
+++ b/fern/docs/pages/catalog/add-ons.mdx
@@ -3,7 +3,7 @@ title: Add Ons
 slug: catalog/add-ons
 ---
 
-Add ons are additional modules or packages that can be assigned to companies in addition to a plan. Companies can have any number of add ons. For a step-by-step guide about creating add ons in Schematic, click [here](/catalog/create-catalog).
+Add ons are additional modules or packages that can be assigned to companies in addition to a plan. Companies can have any number of add ons. For a step-by-step guide about creating add ons in Schematic, click [here](/catalog/plans#create-a-plan).
 
 There are a number of scenarios where you may want to offer add ons, and the most common scenario is that you sell additional functionality that increases the value of your core plan (e.g. Zoom Workplace).
 

--- a/fern/docs/pages/catalog/plans.mdx
+++ b/fern/docs/pages/catalog/plans.mdx
@@ -5,7 +5,7 @@ slug: catalog/plans
 
 A plan in Schematic represents the base billing and entitlement configuration for a given company. For example, if you offer Basic, Standard, and Pro packaging, these would represent mutually exclusive Plans in Schematic.
 
-Schematic limits companies to only 1 plan at a time. For a step-by-step guide about creating a plan in Schematic, click [here](/catalog/create-catalog). To learn how to assign companies to plans, click [here](/catalog/managing-company-plans)
+Schematic limits companies to only 1 plan at a time. For a step-by-step guide about creating a plan in Schematic, click [here](/catalog/plans#create-a-plan). To learn how to assign companies to plans, click [here](/catalog/managing-company-plans)
 
 ![Example showing Schematic plans and add ons](../../assets/images/catalog/catalog-plans-addons-example.png)
 

--- a/fern/docs/pages/developer_resources/sdks/python.mdx
+++ b/fern/docs/pages/developer_resources/sdks/python.mdx
@@ -1,3 +1,8 @@
+---
+title: Python
+slug: developer_resources/sdks/python
+---
+
 # Schematic Python Library
 
 The Schematic Python Library provides convenient access to the Schematic API from
@@ -124,7 +129,7 @@ async def handle_request():
 ```
 
 ## Exception Handling
-All errors thrown by the SDK will be subclasses of [`ApiError`](./src/schematic/core/api_error.py).
+All errors thrown by the SDK will be subclasses of `ApiError`.
 
 ```python
 try:

--- a/fern/docs/pages/integrations/webhooks-plan-changed.mdx
+++ b/fern/docs/pages/integrations/webhooks-plan-changed.mdx
@@ -96,7 +96,7 @@ In SDKs, this field is called `PlanChangeResponseDataSubscriptionChangeAction`, 
 
 <Warning>When a company unsubscribes through the Schematic Checkout component, the customer will keep access to their plan until the end of the billing period. The webhook will be fired when plan access is lost at the end of the billing period.</Warning>
 
-<Note>See [Upgrade/Downgrade Logic](/catalog/changing-plans#upgradedowngrade-logic) for more details about how Schematic determines if a plan change is an upgrade, downgrade, subscribe, or unsubscribe.</Note>
+<Note>See [Upgrade/Downgrade Logic](/catalog/managing-company-plans#upgradedowngrade-logic) for more details about how Schematic determines if a plan change is an upgrade, downgrade, subscribe, or unsubscribe.</Note>
 ## Common scenarios
 
 Below are some common scenarios that you may want to test for and which values you should expect to see in the webhook to identify them.

--- a/fern/docs/pages/playbooks/backfill-and-corrections.mdx
+++ b/fern/docs/pages/playbooks/backfill-and-corrections.mdx
@@ -132,4 +132,4 @@ Events are retained for 365 days, measured from the event's effective `captured_
 
 - [Creating a metered feature](/playbooks/metering)
 - [Negative quantities (usage adjustments)](/billing/usage-based-billing#negative-quantities-usage-adjustments)
-- [The Event object](/api-reference/events/event-object)
+- [The Event object](/api-reference/events/the-event-object)

--- a/fern/docs/pages/playbooks/metering.mdx
+++ b/fern/docs/pages/playbooks/metering.mdx
@@ -22,7 +22,7 @@ Event-based features also support **negative quantities** for adjustments such a
 
 For importing historical usage or correcting events with stale timestamps, see [Backfills and usage corrections](/playbooks/backfill-and-corrections).
 
-To safely retry network calls without double-counting usage, you can submit an optional `idempotency_key` with each event. Duplicate events with the same key — scoped to the same environment and event type — are dropped for 24 hours. See the [Event object](/api-documentation/event#idempotency_key) for details.
+To safely retry network calls without double-counting usage, you can submit an optional `idempotency_key` with each event. Duplicate events with the same key — scoped to the same environment and event type — are dropped for 24 hours. See the [Event object](/api-reference/events/the-event-object#idempotency_key) for details.
 
 <Info>
 You can read more about feature types [here](/feature-management/feature-types).

--- a/fern/docs/pages/using_schematic/who-uses-schematic.mdx
+++ b/fern/docs/pages/using_schematic/who-uses-schematic.mdx
@@ -22,7 +22,7 @@ Product owns that configuration. From Schematic, product teams manage pricing an
 
 Customer success operates in Schematic to manage individual customer accounts, grant overrides, track usage, and handle exceptions.
 
-Customer success teams can also interact with Schematic via the [MCP server](/ai-tooling/for-developers#model-context-protocol-mcp), which enables AI-assisted workflows on top of entitlement data directly from Claude. For example: "pull Acme Corp's usage over the last quarter and integrate into their QBR."
+Customer success teams can also interact with Schematic via the [MCP server](/for-developers#model-context-protocol-mcp), which enables AI-assisted workflows on top of entitlement data directly from Claude. For example: "pull Acme Corp's usage over the last quarter and integrate into their QBR."
 
 ## Finance
 


### PR DESCRIPTION
## Summary

A customer reported broken links in the docs. I ran Fern's own `fern docs broken-links` checker against `docs/pages`, which found **10 broken links across 9 files**. All are fixed, and the checker now passes with zero errors.

## Fixes

| File | Was | Now |
|------|-----|-----|
| `using_schematic/who-uses-schematic.mdx` | `/ai-tooling/for-developers#…` | `/for-developers#model-context-protocol-mcp` |
| `integrations/webhooks-plan-changed.mdx` | `/catalog/changing-plans#…` | `/catalog/managing-company-plans#upgradedowngrade-logic` |
| `playbooks/metering.mdx` | `/api-documentation/event#…` | `/api-reference/events/the-event-object#idempotency_key` |
| `playbooks/backfill-and-corrections.mdx` | `/api-reference/events/event-object` | `/api-reference/events/the-event-object` |
| `catalog/plans.mdx` | `/catalog/create-catalog` | `/catalog/plans#create-a-plan` |
| `catalog/add-ons.mdx` | `/catalog/create-catalog` | `/catalog/plans#create-a-plan` |
| `billing/usage-based-billing.mdx` | `/catalog/create-catalog#…` | `/catalog/plans#create-a-plan` |
| `billing/credit-burndown.mdx` | `…/list-company-credit-grants` | `…/list-company-grants` |
| `developer_resources/sdks/overview.mdx` | link to `…/sdks/python` | fixed by giving `python.mdx` a `slug` |
| `developer_resources/sdks/python.mdx` | `[ApiError](./src/…/api_error.py)` | de-linked to inline `` `ApiError` `` |

## Root causes
- The three `/catalog/create-catalog` links broke when that page was deleted in #249; its "Create a Plan or Add on" walkthrough moved into the Plans page (`#create-a-plan`).
- `python.mdx` was the only SDK page missing a frontmatter `slug:`, so it resolved to an auto-generated URL nothing matched. Adding the slug fixed both its own URL and the inbound link from the SDK overview.

## Verification
`fern docs broken-links` → `✓ All checks passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)