### PR TITLE
docs: document startTrialIfAvailable option for initializeWithPlan

### DIFF
--- a/fern/docs/pages/components/advanced-usage.mdx
+++ b/fern/docs/pages/components/advanced-usage.mdx
@@ -78,17 +78,20 @@ In the above example, while the plan is pre-selected, the user will still be abl
 
 ```ts
 const config = {
-  planId: 'plan_abc123',      // pre-select a Plan
-  addOnIds: ['plan_addon123'],   // pre-select 1 or more add ons
+  planId: 'plan_abc123',           // pre-select a Plan
+  addOnIds: ['plan_addon123'],     // pre-select 1 or more add ons
   skipped: {
     planStage: true,               // if true, skip plan selection
     addOnStage: true               // if true, skip add on selection
-  }
-  hideSkipped:  true               // if true, hide skipped stages from breadcrumb navigation
+  },
+  hideSkipped: true,               // if true, hide skipped stages from breadcrumb navigation
+  startTrialIfAvailable: true      // if true (default), start a trial when the plan is trialable and the company is eligible
 };
 
 initializeWithPlan(config);
 ```
+
+When the pre-selected plan offers a trial and the company is eligible, `initializeWithPlan` starts checkout in trial mode by default. This matches the behavior of the in-dialog "Start trial" button, so customers using the bypass flow get the same trial they would have gotten by clicking through the plan stage. Pass `startTrialIfAvailable: false` to charge immediately instead.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

- Documents the new `startTrialIfAvailable` option on the `initializeWithPlan` bypass config introduced in SchematicHQ/schematic-js#1282.
- When the pre-selected plan offers a trial and the company is eligible, `initializeWithPlan` now starts checkout in trial mode by default to match the in-dialog "Start trial" button.
- Callers can pass `startTrialIfAvailable: false` to charge immediately instead.

Refs [SCH-6507](https://linear.app/schematic/issue/SCH-6507/trial-checkout-creates-subscriptions-with-no-trial-period).

## Test plan

- [ ] Visual check of the rendered page at /components/advanced-usage in a Fern preview
- [ ] Confirm the code block reads cleanly and the new explanatory paragraph appears above the Examples section

🤖 Generated with [Claude Code](https://claude.com/claude-code)