### PR TITLE
docs: document plan-changed browser event for post-unsubscribe flows

### DIFF
--- a/fern/docs/pages/components/advanced-usage.mdx
+++ b/fern/docs/pages/components/advanced-usage.mdx
@@ -121,42 +121,7 @@ See the code: https://github.com/SchematicHQ/schematic-next-example/blob/main/sr
 
 ## Reacting to Plan Changes in the Browser
 
-When a checkout completes inside a Schematic component, the component dispatches a `plan-changed` event on the `window`. You can listen for this event to run your own logic after a user subscribes, upgrades, downgrades, or unsubscribes, without polling or wiring up a webhook.
-
-```ts
-window.addEventListener("plan-changed", (event) => {
-  // event.detail describes what changed
-});
-```
-
-The shape of `event.detail` depends on what happened:
-
-- When a user completes a checkout (subscribe, upgrade, or downgrade), `event.detail` is a [`BillingSubscriptionResponseData`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/BillingSubscriptionResponseData.ts) object describing the new subscription.
-- When a user unsubscribes, `event.detail` is a delete response of the shape `{ deleted?: boolean }`.
-
-<Info>This is a client-side browser event, separate from the server-side [`company.plan_changed` webhook](/integrations/webhooks/plan-changed). Use the browser event to react in your front end (for example, redirecting the user), and use the webhook to trigger backend or internal workflows.</Info>
-
-### Sending users to a feedback form after they unsubscribe
-
-A common use case is to show a cancellation survey or feedback form after a user unsubscribes. Listen for `plan-changed`, check for the delete response shape, and redirect:
-
-```tsx
-useEffect(() => {
-  const handlePlanChanged = (event: CustomEvent) => {
-    // An unsubscribe returns a delete response: { deleted?: boolean }
-    if (event.detail?.deleted) {
-      window.location.href = "/cancellation-feedback";
-    }
-  };
-
-  window.addEventListener("plan-changed", handlePlanChanged as EventListener);
-  return () => {
-    window.removeEventListener("plan-changed", handlePlanChanged as EventListener);
-  };
-}, []);
-```
-
-You can apply the same pattern to trigger an upsell offer or a welcome flow after a successful subscribe by inspecting the `BillingSubscriptionResponseData` payload instead.
+Schematic components dispatch a `plan-changed` event on the `window` when a checkout completes, so you can run your own logic after a user subscribes, upgrades, downgrades, or unsubscribes. This includes patterns like redirecting users to a cancellation feedback form after they unsubscribe. See [Checkout Flow Events](/components/customer-portal#checkout-flow-events) for the event payload and examples.
 
 ## Collecting Taxes
 

--- a/fern/docs/pages/components/advanced-usage.mdx
+++ b/fern/docs/pages/components/advanced-usage.mdx
@@ -119,6 +119,45 @@ You can see a full example, including error handling and loading states in our e
 Check it out online: https://schematic-next-example.vercel.app/custom-checkout
 See the code: https://github.com/SchematicHQ/schematic-next-example/blob/main/src/app/custom-checkout/page.tsx
 
+## Reacting to Plan Changes in the Browser
+
+When a checkout completes inside a Schematic component, the component dispatches a `plan-changed` event on the `window`. You can listen for this event to run your own logic after a user subscribes, upgrades, downgrades, or unsubscribes, without polling or wiring up a webhook.
+
+```ts
+window.addEventListener("plan-changed", (event) => {
+  // event.detail describes what changed
+});
+```
+
+The shape of `event.detail` depends on what happened:
+
+- When a user completes a checkout (subscribe, upgrade, or downgrade), `event.detail` is a [`BillingSubscriptionResponseData`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/BillingSubscriptionResponseData.ts) object describing the new subscription.
+- When a user unsubscribes, `event.detail` is a delete response of the shape `{ deleted?: boolean }`.
+
+<Info>This is a client-side browser event, separate from the server-side [`company.plan_changed` webhook](/integrations/webhooks/plan-changed). Use the browser event to react in your front end (for example, redirecting the user), and use the webhook to trigger backend or internal workflows.</Info>
+
+### Sending users to a feedback form after they unsubscribe
+
+A common use case is to show a cancellation survey or feedback form after a user unsubscribes. Listen for `plan-changed`, check for the delete response shape, and redirect:
+
+```tsx
+useEffect(() => {
+  const handlePlanChanged = (event: CustomEvent) => {
+    // An unsubscribe returns a delete response: { deleted?: boolean }
+    if (event.detail?.deleted) {
+      window.location.href = "/cancellation-feedback";
+    }
+  };
+
+  window.addEventListener("plan-changed", handlePlanChanged as EventListener);
+  return () => {
+    window.removeEventListener("plan-changed", handlePlanChanged as EventListener);
+  };
+}, []);
+```
+
+You can apply the same pattern to trigger an upsell offer or a welcome flow after a successful subscribe by inspecting the `BillingSubscriptionResponseData` payload instead.
+
 ## Collecting Taxes
 
 Schematic supports Stripe Tax (and 3rd party tax providers that integrate with Stripe Tax) to simplify collecting tax and ensuring compliance with tax laws. Components can be configured to collect tax information from the user (e.g. billing address) and generate the correct taxes at checkout. 

--- a/fern/docs/pages/components/customer-portal.mdx
+++ b/fern/docs/pages/components/customer-portal.mdx
@@ -110,11 +110,13 @@ A few values below are numbers that represent dates (specifically, seconds since
 | trialEnd? | `Date?` | If the subscription is a trial, the date when the trial will end. |
 | trialEndSetting? | `string?` | If the subscription is a trial, the setting for when the trial will end. Can be `end_of_trial` or `end_of_billing_period`. |
 
+<Info>This `plan-changed` event is a client-side browser event, separate from the server-side [`company.plan_changed` webhook](/integrations/webhooks/plan-changed). Use the browser event to react in your front end (for example, refreshing the page or redirecting the user), and use the webhook to trigger backend or internal workflows.</Info>
+
 ### Unsubscribes
 
 The same `plan-changed` event also fires when a customer unsubscribes. In that case the `detail` property is a delete response of the shape `{ deleted?: boolean }` rather than the subscription object above, so you can branch on it to handle cancellations differently.
 
-A common use case is to show a cancellation survey or feedback form after a user unsubscribes. Listen for the event, check for the delete response shape, and redirect:
+A common use case is to show a cancellation survey or feedback form after a user unsubscribes. Listen for the event, check for the delete response shape, and handle accordingly:
 
 ```javascript
 window.addEventListener("plan-changed", (event) => {
@@ -124,5 +126,3 @@ window.addEventListener("plan-changed", (event) => {
   }
 });
 ```
-
-<Info>This `plan-changed` event is a client-side browser event, separate from the server-side [`company.plan_changed` webhook](/integrations/webhooks/plan-changed). Use the browser event to react in your front end (for example, refreshing the page or redirecting the user), and use the webhook to trigger backend or internal workflows.</Info>

--- a/fern/docs/pages/components/customer-portal.mdx
+++ b/fern/docs/pages/components/customer-portal.mdx
@@ -109,3 +109,20 @@ A few values below are numbers that represent dates (specifically, seconds since
 | totalPrice | `number` | The total price of the subscription in cents. (divide by 100 to get the price in $) |
 | trialEnd? | `Date?` | If the subscription is a trial, the date when the trial will end. |
 | trialEndSetting? | `string?` | If the subscription is a trial, the setting for when the trial will end. Can be `end_of_trial` or `end_of_billing_period`. |
+
+### Unsubscribes
+
+The same `plan-changed` event also fires when a customer unsubscribes. In that case the `detail` property is a delete response of the shape `{ deleted?: boolean }` rather than the subscription object above, so you can branch on it to handle cancellations differently.
+
+A common use case is to show a cancellation survey or feedback form after a user unsubscribes. Listen for the event, check for the delete response shape, and redirect:
+
+```javascript
+window.addEventListener("plan-changed", (event) => {
+  // An unsubscribe returns a delete response: { deleted?: boolean }
+  if (event.detail?.deleted) {
+    window.location.href = "/cancellation-feedback";
+  }
+});
+```
+
+<Info>This `plan-changed` event is a client-side browser event, separate from the server-side [`company.plan_changed` webhook](/integrations/webhooks/plan-changed). Use the browser event to react in your front end (for example, refreshing the page or redirecting the user), and use the webhook to trigger backend or internal workflows.</Info>


### PR DESCRIPTION
## Summary

Documents the client-side `plan-changed` event that Schematic components dispatch on the `window` when a checkout completes. This came out of a customer thread where they asked how to trigger a survey/offer for users who cancel or downgrade.

Added a new section to `components/advanced-usage.mdx` covering:
- Listening for the `plan-changed` window event
- The `event.detail` payload: `BillingSubscriptionResponseData` on subscribe/upgrade/downgrade, and `{ deleted?: boolean }` on unsubscribe
- The distinction between this browser event and the server-side `company.plan_changed` webhook
- A worked example redirecting users to a feedback form after they unsubscribe

Source: customer Slack thread (Cole/Gio confirmed the event behavior).

Closes DEV-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)