### PR TITLE
add redis devDependency to node SDK package.json config

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -106,6 +106,7 @@ groups:
             devDependencies:
               esbuild: ^0.25.9
               miniflare: "^4.20260421.0"
+              redis: "^4.7.0"
             scripts:
               build: node build.js
               build:legacy: tsc


### PR DESCRIPTION
The schematic-node credit-lease PR (SchematicHQ/schematic-node#121) adds Redis-backed integration tests that need `redis` as a devDependency. Adding it to the ts-sdk `packageJson` block so Fern regenerations preserve it.