### PR TITLE
Document webhook delivery and retry behavior

### DIFF
--- a/fern/docs/pages/integrations/webhooks.mdx
+++ b/fern/docs/pages/integrations/webhooks.mdx
@@ -152,7 +152,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 
 ## Delivery and retries
 
-Schematic delivers webhooks asynchronously. Your endpoint should acknowledge receipt by responding with any `2xx` status code. Respond promptly: slow responses can be treated as failures once the request times out.
+Schematic delivers webhooks asynchronously. Your endpoint should acknowledge receipt by responding with any `2xx` status code.
 
 If your endpoint responds with a non-`2xx` status (anything `300` or above) or the request times out, Schematic treats the delivery as failed and retries it. Retries use exponential backoff with jitter, up to 5 retries after the initial attempt (6 delivery attempts in total). Once those attempts are exhausted, the event is not delivered again.
 
@@ -160,7 +160,7 @@ If your endpoint responds with a non-`2xx` status (anything `300` or above) or t
 
 ### Endpoint health
 
-If an endpoint fails consistently — a failure rate of 90% or higher across at least 25 events in a rolling 24-hour window — Schematic automatically deactivates it so it stops sending to a broken destination. You can re-enable the endpoint from the webhooks page in the dashboard once the issue is resolved.
+If an endpoint fails consistently, Schematic automatically deactivates it so it stops sending to a broken destination. Our threshold for deactivation is a failure rate of 90% or higher across at least 25 events in a rolling 24-hour window. You can re-enable the endpoint from the webhooks page in the dashboard once the issue is resolved.
 
 ## Developer Tooling
 

--- a/fern/docs/pages/integrations/webhooks.mdx
+++ b/fern/docs/pages/integrations/webhooks.mdx
@@ -154,7 +154,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 
 Schematic delivers webhooks asynchronously. Your endpoint should acknowledge receipt by responding with any `2xx` status code. Respond promptly: slow responses can be treated as failures once the request times out.
 
-If your endpoint responds with a non-`2xx` status (anything `300` or above) or the request times out, Schematic treats the delivery as failed and retries it. Retries use exponential backoff with jitter, for up to 5 attempts per event. Once those attempts are exhausted, the event is not delivered again.
+If your endpoint responds with a non-`2xx` status (anything `300` or above) or the request times out, Schematic treats the delivery as failed and retries it. Retries use exponential backoff with jitter, up to 5 retries after the initial attempt (6 delivery attempts in total). Once those attempts are exhausted, the event is not delivered again.
 
 <Note>Because an event can be delivered more than once (for example, if a retry overlaps a slow success, or your endpoint processes the request but its response is lost in transit), design your handler to be idempotent. The webhook payload includes enough context to deduplicate events on your side.</Note>
 

--- a/fern/docs/pages/integrations/webhooks.mdx
+++ b/fern/docs/pages/integrations/webhooks.mdx
@@ -150,6 +150,18 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 
 <Warning>Always use your framework's raw body middleware when verifying signatures — parsed or re-serialized bodies will not match the original signature.</Warning>
 
+## Delivery and retries
+
+Schematic delivers webhooks asynchronously. Your endpoint should acknowledge receipt by responding with any `2xx` status code. Respond promptly: slow responses can be treated as failures once the request times out.
+
+If your endpoint responds with a non-`2xx` status (anything `300` or above) or the request times out, Schematic treats the delivery as failed and retries it. Retries use exponential backoff with jitter, for up to 5 attempts per event. Once those attempts are exhausted, the event is not delivered again.
+
+<Note>Because an event can be delivered more than once (for example, if a retry overlaps a slow success, or your endpoint processes the request but its response is lost in transit), design your handler to be idempotent. The webhook payload includes enough context to deduplicate events on your side.</Note>
+
+### Endpoint health
+
+If an endpoint fails consistently — a failure rate of 90% or higher across at least 25 events in a rolling 24-hour window — Schematic automatically deactivates it so it stops sending to a broken destination. You can re-enable the endpoint from the webhooks page in the dashboard once the issue is resolved.
+
 ## Developer Tooling
 
 On the webhooks page in Schematic, you can find a log of all webhooks Schematic has sent for your account. We will only show events that have an associated webhook configured.


### PR DESCRIPTION
Adds a "Delivery and retries" section to the public webhooks docs page.

Customers had no documentation on how Schematic handles outbound webhook delivery failures. This documents the actual behavior in the API: asynchronous delivery, 2xx acknowledgement, retry with exponential backoff (up to 5 attempts), the need for idempotent handlers, and automatic endpoint deactivation when an endpoint fails consistently (90%+ over 25+ events in 24h).