### PR TITLE
docs: plan versioning — catalog config, trials, add-ons (Batch 3, SCHX-533)

### DIFF
--- a/fern/docs/pages/catalog/add-ons.mdx
+++ b/fern/docs/pages/catalog/add-ons.mdx
@@ -7,6 +7,10 @@ Add ons are additional modules or packages that can be assigned to companies in 
 
 There are a number of scenarios where you may want to offer add ons, and the most common scenario is that you sell additional functionality that increases the value of your core plan (e.g. Zoom Workplace).
 
+## Add on versions
+
+Like plans, add ons are versioned. Editing an add on creates a new draft version that you publish when you're ready, and at publish you decide what happens to companies on the current version — migrate all, choose which companies migrate, or keep them on their current version. Add ons are versioned **independently** of base plans: publishing a new add on version only affects companies that have that add on, not their base plan. See [Plan Versions](/catalog/plans#plan-versions) for how versioning and migrations work.
+
 ## Usage-based Add Ons
 
 Add ons can add usage-based entitlements, both trait-based or event-based. When adding an usage-based entitlement to an add on, the entitlement can either introduce a brand new entitlement or override an existing entitlement on the plan.

--- a/fern/docs/pages/catalog/configure-catalog.mdx
+++ b/fern/docs/pages/catalog/configure-catalog.mdx
@@ -55,6 +55,8 @@ The plan companies are moved to when their trial period expires.
 
 The plans that your end users can choose to downgrade from or upgrade to. If enabled, each plan included in Live Plans will appear as an option in the checkout flow.
 
+Live Plans always surface each plan's **latest published version**. When you publish a new version, new checkouts automatically use it; companies already on a prior version stay there until you [migrate them](/catalog/plans#plan-version-migrations). The same applies to the Initial, Fallback, and Trial Expiry plans below — they resolve to the plan's latest published version.
+
 Companies in Schematic may be assigned plans that are not included here, but there will be no option to independently subscribe to them using Schematic Components.
 
 ### Custom Plans

--- a/fern/docs/pages/catalog/configure-catalog.mdx
+++ b/fern/docs/pages/catalog/configure-catalog.mdx
@@ -55,7 +55,7 @@ The plan companies are moved to when their trial period expires.
 
 The plans that your end users can choose to downgrade from or upgrade to. If enabled, each plan included in Live Plans will appear as an option in the checkout flow.
 
-Live Plans always surface each plan's **latest published version**. When you publish a new version, new checkouts automatically use it; companies already on a prior version stay there until you [migrate them](/catalog/plans#plan-version-migrations). The same applies to the Initial, Fallback, and Trial Expiry plans below — they resolve to the plan's latest published version.
+Live Plans always surface each plan's **latest** published version. Companies already on a prior version stay there until you [migrate them](/catalog/plans#plan-version-migrations). The same applies to the Initial, Fallback, and Trial Expiry plans below — they resolve to the plan's latest published version.
 
 Companies in Schematic may be assigned plans that are not included here, but there will be no option to independently subscribe to them using Schematic Components.
 
@@ -68,7 +68,7 @@ Often, an enterprise plan will have custom pricing that cannot easily be display
 
 ### Live Add Ons
 
-The add ons that your end users can select. If enabled, each add on included in Live Add ons will appear as an option in the checkout flow.
+The add ons that your end users can select. If enabled, each add on included in Live Add ons will appear as an option in the checkout flow. Similar to Live Plans, Live Add Ons will always show the latest published version in checkout.
 
 Companies in Schematic may be assigned add ons that are not included here, but there will be no option to independently subscribe to them using Schematic Components.
 

--- a/fern/docs/pages/catalog/trials.mdx
+++ b/fern/docs/pages/catalog/trials.mdx
@@ -3,7 +3,7 @@ title: Trials
 slug: catalog/trials
 ---
 
-You can enable whether a plan has a trial or not when creating or editing a plan. Because editing a plan [creates a new plan version](/catalog/plans#plan-versions), a changed trial configuration takes effect for companies that start the plan on (or are migrated to) the new version. When a trial period is defined for a plan, Schematic will ensure that the company receives the corresponding entitlements for that period the first time they are assigned that plan. 
+You can enable whether a plan has a trial or not when creating or editing a plan. Because editing a plan [creates a new plan version](/catalog/plans#plan-versions), trials configurations can be adjusted whenever a new plan version is published. When a trial period is defined for a plan, Schematic will ensure that the company receives the corresponding entitlements for that period the first time they are assigned that plan. 
 
 You can configure whether payment is required up front or not in the Catalog configuration tab -- if it is required, the company will convert into the corresponding paid plan automatically; if not, they will downgrade to your default plan.
 

--- a/fern/docs/pages/catalog/trials.mdx
+++ b/fern/docs/pages/catalog/trials.mdx
@@ -3,7 +3,7 @@ title: Trials
 slug: catalog/trials
 ---
 
-You can enable whether a plan has a trial or not when creating or editing a plan. When a trial period is defined for a plan, Schematic will ensure that the company receives the corresponding entitlements for that period the first time they are assigned that plan. 
+You can enable whether a plan has a trial or not when creating or editing a plan. Because editing a plan [creates a new plan version](/catalog/plans#plan-versions), a changed trial configuration takes effect for companies that start the plan on (or are migrated to) the new version. When a trial period is defined for a plan, Schematic will ensure that the company receives the corresponding entitlements for that period the first time they are assigned that plan. 
 
 You can configure whether payment is required up front or not in the Catalog configuration tab -- if it is required, the company will convert into the corresponding paid plan automatically; if not, they will downgrade to your default plan.
 


### PR DESCRIPTION
Part of the plan versioning docs overhaul (parent: SCHX-529). **Batch 3 of 8.**

## What changed
- **`catalog/configure-catalog.mdx`** — Live Plans (and the Initial / Fallback / Trial Expiry plans) resolve to each plan's **latest published version**; publishing a new version routes new checkouts to it while existing companies stay until migrated.
- **`catalog/trials.mdx`** — clarifies that editing a plan **creates a new version**, so a changed trial configuration applies to companies that start on (or are migrated to) the new version.
- **`catalog/add-ons.mdx`** — adds an "Add on versions" section: add ons are versioned just like plans (draft → publish → migrate) and **independently** of base plans. Verified in-app (each add on shows its own version pill, e.g. `v1`).

## Screenshots
No versioning-specific screenshots needed here. The Configuration-tab images (`configure-table`, `catalog-config`, `catalog-trial-rules`, `catalog-rules`) are aged from the general UI refresh and will be handled in the screenshot pass.

> Links to `#plan-versions` / `#plan-version-migrations` resolve once Batch 1 (#347) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)