### PR TITLE
docs: plan versioning — setup guides (Batch 4, SCHX-534)

### DIFF
--- a/fern/docs/pages/billing/credit-burndown.mdx
+++ b/fern/docs/pages/billing/credit-burndown.mdx
@@ -137,6 +137,8 @@ When you're finished, your credit bundles should look like this:
 
 <Info>The cost you set for these bundles will be the basis for Recognizing the Revenue from these credits.</Info>
 
+<Info>Your new plan starts as an unpublished **draft** (version 1) — adding the credit grant and features above edits that draft. Before customers can use it, open the plan and click **Publish version** in the banner at the top of the page. Because this is the plan's first version, there are no existing subscribers to migrate. See [Plan Versions](/catalog/plans#plan-versions) for more.</Info>
+
 ### 6. Add this plan and credit bundles to the Catalog so Customers can use it. 
 
 Now that we've finished setting up our plan and credit bundles, we'll add them to our Catalog so Customers can use them.


### PR DESCRIPTION
Part of the plan versioning docs overhaul (parent: SCHX-529). **Batch 4 of 8.**

## What changed
- **`billing/credit-burndown.mdx`** — the guide builds a brand-new plan but never said it starts as an unpublished **draft (v1)** that must be **published** before customers can use it. Added a concise publish note before the "add to Catalog" step (and a pointer to [Plan Versions](/catalog/plans#plan-versions)).
- **`catalog/guides-first-plans.mdx`** — reviewed; it already reflects the draft → Save → Publish flow (recently updated), so no change.

## Screenshots
The credit-burndown step screenshots (`burndown-*`) are from the pre-stepper plan-builder UI and are candidates for the screenshot refresh pass; deferred (not blocking the versioning copy).

> Link to `#plan-versions` resolves once Batch 1 (#347) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)