### PR TITLE
docs: plan versioning — Stripe per-version prices (Batch 7, SCHX-537)

### DIFF
--- a/fern/docs/pages/integrations/stripe-integration-guide.mdx
+++ b/fern/docs/pages/integrations/stripe-integration-guide.mdx
@@ -39,6 +39,8 @@ The following Schematic concepts are synced to Stripe products/prices
 
 When you setup one of these Schematic concepts, you are given the option to map these to an existing product/price in Stripe or to create a new product/price in Stripe to map to. 
 
+<Info>Because plans and add ons are [versioned](/catalog/plans#plan-versions), the base Stripe **product** is shared across all of a plan's versions, but **prices are version-specific**. When you publish a new version that changes pricing, Schematic creates new Stripe prices for that version and leaves the existing prices intact, so companies on older versions keep their current pricing until they are migrated.</Info>
+
 ![Stripe New Product and Prices](../../assets/images/stripe/stripe-new-product-prices.png)
 
 ![Stripe Existing Product and Prices](../../assets/images/stripe/stripe-existing-product-prices.png)

--- a/fern/docs/pages/integrations/stripe-overview.mdx
+++ b/fern/docs/pages/integrations/stripe-overview.mdx
@@ -31,6 +31,8 @@ If you want all companies to be synced to Stripe from the moment they are create
 
 Plans are the core element of a product catalog. Schematic plans can be mapped to Stripe products and prices. When configuring a plan, you can choose to map to an existing Stripe product and price or create a new one. Schematic supports configuring both monthly and yearly prices for plans.
 
+Because plans are [versioned](/catalog/plans#plan-versions), the underlying Stripe **product** is shared across a plan's versions, while each plan **version** has its own Stripe **prices**. Publishing a new version with a pricing change creates new Stripe prices for that version; companies on prior versions keep their existing prices until they are migrated. When a version is archived, its prices are deactivated in Stripe.
+
 Mapping a plan to Stripe enables Schematic components (e.g. checkout flow) to support the plan for users. [See here for more details](#schematic-components)
 
 {/* This video is a quick walkthrough of how to set up a plan in Schematic and map it to Stripe products and prices.


### PR DESCRIPTION
Part of the plan versioning docs overhaul (parent: SCHX-529). **Batch 7 of 8.**

## What changed
- **`integrations/stripe-overview.mdx`** and **`integrations/stripe-integration-guide.mdx`** — explain how Stripe mapping works under versioning: the base Stripe **product** is shared across a plan's versions, but **prices are version-specific**. Publishing a new version with a pricing change creates new Stripe prices and leaves the existing ones intact (so companies on prior versions keep their pricing until migrated); archiving a version deactivates its prices.

## Notes
- `stripe-faq.mdx` ("Plan Change Flows" / Live-Plans) reviewed — no versioning-specific correction needed; the Live-Plans version behavior is covered in Batch 3 (#349).
- Stripe setup screenshots are aged from the general UI refresh; deferred to the screenshot pass.

> Link to `#plan-versions` resolves once Batch 1 (#347) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)