### PR TITLE
Add business-framed Use Cases docs section

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -60,10 +60,18 @@ navigation:
             contents:
               - page: Close custom deals
                 path: ./docs/pages/use-cases/custom-deals.mdx
+              - page: Run sales-assisted trials and POCs
+                path: ./docs/pages/use-cases/sales-assisted-trials.mdx
+              - page: Expand accounts with upsells and add-ons
+                path: ./docs/pages/use-cases/expand-accounts.mdx
           - section: Customer Management
             contents:
               - page: Manage exceptions with overrides
                 path: ./docs/pages/use-cases/overrides.mdx
+              - page: Spot churn and expansion with usage signals
+                path: ./docs/pages/use-cases/usage-signals.mdx
+              - page: Stay ahead of renewals and expirations
+                path: ./docs/pages/use-cases/renewals.mdx
           - section: Operations
             contents:
               - page: Reprice and repackage safely

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -38,6 +38,63 @@ navigation:
         contents:
           - page: Who Uses Schematic
             path: ./docs/pages/using_schematic/who-uses-schematic.mdx
+      - section: Use Cases
+        contents:
+          - page: Overview
+            path: ./docs/pages/use-cases/overview.mdx
+          - section: Product-Led Growth
+            contents:
+              - page: Convert and expand users self-serve
+                path: ./docs/pages/use-cases/self-serve-checkout.mdx
+              - page: Give customers a self-service portal
+                path: ./docs/pages/use-cases/customer-portal.mdx
+              - page: Run free trials
+                path: ./docs/pages/use-cases/free-trials.mdx
+              - page: Price by usage
+                path: ./docs/pages/use-cases/usage-based-pricing.mdx
+              - page: Bill for usage
+                path: ./docs/pages/use-cases/usage-billing.mdx
+              - page: Run credit-based billing
+                path: ./docs/pages/use-cases/credit-billing.mdx
+          - section: Sales-Led Growth
+            contents:
+              - page: Close custom deals
+                path: ./docs/pages/use-cases/custom-deals.mdx
+          - section: Customer Management
+            contents:
+              - page: Manage exceptions with overrides
+                path: ./docs/pages/use-cases/overrides.mdx
+          - section: Operations
+            contents:
+              - page: Reprice and repackage safely
+                path: ./docs/pages/use-cases/plan-versioning.mdx
+              - page: Keep Stripe in sync
+                path: ./docs/pages/use-cases/stripe-sync.mdx
+              - page: Automate with webhooks and AI
+                path: ./docs/pages/use-cases/automation.mdx
+      - section: Playbooks
+        contents:
+          - page: Overview
+            slug: overview
+            path: ./docs/pages/playbooks/overview.mdx
+          - page: Creating a metered feature
+            slug: metering
+            path: ./docs/pages/playbooks/metering.mdx
+          - page: Backfills and usage corrections
+            slug: backfill-and-corrections
+            path: ./docs/pages/playbooks/backfill-and-corrections.mdx
+          - page: Rolling out beta functionality with Flags
+            slug: rollout
+            path: ./docs/pages/playbooks/rollout.mdx
+          - page: Handling customer exceptions and feature trials
+            slug: exceptions
+            path: ./docs/pages/playbooks/exceptions.mdx
+          - page: Automatically provision customers using Stripe
+            slug: provisioning-stripe
+            path: ./docs/pages/playbooks/provisioning-stripe.mdx
+          - page: Build a slack webhook
+            slug: slack-webhook
+            path: ./docs/pages/playbooks/slack-webhook.mdx
       - section: Quickstart
         contents:
           - page: Quickstart
@@ -273,29 +330,6 @@ navigation:
                 path: ./docs/pages/integrations/webhooks-plan-changed.mdx
               - page: Entitlement & Credit Trigger Webhooks
                 path: ./docs/pages/integrations/webhooks-entitlement-triggers.mdx
-      - section: Playbooks
-        contents:
-          - page: Overview
-            slug: overview
-            path: ./docs/pages/playbooks/overview.mdx
-          - page: Creating a metered feature
-            slug: metering
-            path: ./docs/pages/playbooks/metering.mdx
-          - page: Backfills and usage corrections
-            slug: backfill-and-corrections
-            path: ./docs/pages/playbooks/backfill-and-corrections.mdx
-          - page: Rolling out beta functionality with Flags
-            slug: rollout
-            path: ./docs/pages/playbooks/rollout.mdx
-          - page: Handling customer exceptions and feature trials
-            slug: exceptions
-            path: ./docs/pages/playbooks/exceptions.mdx
-          - page: Automatically provision customers using Stripe
-            slug: provisioning-stripe
-            path: ./docs/pages/playbooks/provisioning-stripe.mdx
-          - page: Build a slack webhook
-            slug: slack-webhook
-            path: ./docs/pages/playbooks/slack-webhook.mdx
   - tab: api
     layout:
       - page: Resources

--- a/fern/docs/pages/use-cases/automation.mdx
+++ b/fern/docs/pages/use-cases/automation.mdx
@@ -8,7 +8,9 @@ Changes in Schematic often need to kick off work somewhere else. A new company s
 
 ## Common approaches
 
-Teams poll the API on a schedule, or bolt notification calls onto their application code wherever a relevant change happens. Polling is wasteful and laggy, and scattered notification logic is easy to miss, easy to duplicate, and hard to keep consistent as the product grows.
+Teams usually reach for one of two patterns. Either they poll the API on a schedule, scanning for companies, plans, or usage that changed since the last run, or they bolt notification calls directly onto application code at each spot where something relevant happens, posting to Slack here and updating the CRM there.
+
+Neither holds up well. Polling is wasteful when nothing changed and laggy when something does, and it can't catch events that happen and resolve between runs. Inline notification calls scatter the same concern across the codebase, so it's easy to miss a code path, easy to double-send, and hard to keep consistent as the product grows. In both cases the automation logic is tangled into your application rather than driven cleanly off the events themselves.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/automation.mdx
+++ b/fern/docs/pages/use-cases/automation.mdx
@@ -1,0 +1,22 @@
+---
+title: Automate with webhooks and AI
+slug: use-cases/automation
+description: Drive Slack, CRM, and AI-assisted workflows off Schematic events.
+---
+
+Changes in Schematic often need to kick off work somewhere else. A new company should notify the team, a plan change should update the CRM, usage crossing a limit or credits running low should trigger an alert or an onboarding step.
+
+## Common approaches
+
+Teams poll the API on a schedule, or bolt notification calls onto their application code wherever a relevant change happens. Polling is wasteful and laggy, and scattered notification logic is easy to miss, easy to duplicate, and hard to keep consistent as the product grows.
+
+## How Schematic fits in
+
+Subscribe to Schematic webhooks for the events you care about, company and plan changes, entitlement and credit triggers, and route them to Slack, your CRM, or any endpoint. For ad-hoc and AI-assisted workflows, the Schematic MCP server lets your team query and manage entitlement data directly from AI tools like Claude, for example pulling a company's usage for a quarterly review.
+
+## Learn more
+
+- [Webhooks](/integrations/webhooks) — the available events and how to set up an endpoint.
+- [Entitlement & Credit Trigger Webhooks](/integrations/webhooks/entitlement-triggers) — fire on usage and limit thresholds.
+- [Build a Slack webhook](/playbooks/slack-webhook) — a worked example routing events to Slack.
+- [MCP Server](/for-developers#model-context-protocol-mcp) — manage entitlement data from AI tools.

--- a/fern/docs/pages/use-cases/credit-billing.mdx
+++ b/fern/docs/pages/use-cases/credit-billing.mdx
@@ -8,7 +8,9 @@ Credit models, where customers buy a balance that burns down as they use feature
 
 ## Common approaches
 
-Teams track a credit balance in their own database, decrement it on every action, build top-up purchase flows, and handle expiration, grant ordering, and refunds themselves. Getting consumption rates, which credits burn first, and revenue recognition right is a substantial build that grows with every new feature.
+Teams typically track a credit balance in their own database, decrement it on every billable action, and build purchase flows so customers can top up when they run low. The core loop, grant some credits, subtract as they're used, block when the balance hits zero, is straightforward to prototype.
+
+The depth shows up in the details. Credits come from different sources, the monthly plan grant, purchased bundles, promotional credits, refunds, and each typically has its own expiration, which forces a decision about which credits burn first. On top of that you need per-feature consumption rates that can change over time, auto top-up so customers don't get cut off mid-task, refunds when an action fails, and a revenue-recognition story finance can trust. Building all of that, and keeping it correct as you add features, is a substantial project in its own right.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/credit-billing.mdx
+++ b/fern/docs/pages/use-cases/credit-billing.mdx
@@ -1,0 +1,20 @@
+---
+title: Run credit-based billing
+slug: use-cases/credit-billing
+description: Sell a prepaid credit balance that burns down as customers use features.
+---
+
+Credit models, where customers buy a balance that burns down as they use features, have become a popular way to price AI and consumption products. They unify many features under a single metric, let customers prepay without billing surprises, and make it easy to top up for more.
+
+## Common approaches
+
+Teams track a credit balance in their own database, decrement it on every action, build top-up purchase flows, and handle expiration, grant ordering, and refunds themselves. Getting consumption rates, which credits burn first, and revenue recognition right is a substantial build that grows with every new feature.
+
+## How Schematic fits in
+
+Create a credit type, grant credits on a plan each billing period, and set how many credits each feature consumes. Schematic burns down the balance as features are used, sells top-up bundles through checkout, supports auto top-up so customers don't get interrupted, and handles refunds via negative-quantity events. Customers see their balance in the customer portal, and the credit pricing you set drives revenue recognition.
+
+## Learn more
+
+- [Credit Burndown Billing Model](/billing/credit-burndown) — set up credit types, grants, consumption rates, and bundles.
+- [Usage Based Billing Models](/billing/usage-based-billing) — how credit burndown relates to the other usage models.

--- a/fern/docs/pages/use-cases/custom-deals.mdx
+++ b/fern/docs/pages/use-cases/custom-deals.mdx
@@ -1,0 +1,21 @@
+---
+title: Close custom deals
+slug: use-cases/custom-deals
+description: Package bespoke pricing and entitlements for negotiated contracts without touching code.
+---
+
+Sales-led deals rarely fit neatly into the good-better-best plans on your pricing page. Negotiated contracts come with their own pricing and their own mix of entitlements, and you need to honor them without forking your application for every customer.
+
+## Common approaches
+
+Teams add one-off flags or special-case config in application code for each negotiated account. Over time that becomes a tangle of bespoke logic that's hard to audit, easy to break, and harder still to change when the customer renews on different terms.
+
+## How Schematic fits in
+
+Build a custom plan with the negotiated entitlements and pricing and assign it to the company, or layer per-company overrides on top of a standard plan. Custom plans can be kept off your public pricing table and shown instead with a "talk to us" message, and everything, the entitlements, the pricing, the assignment, is managed from Schematic rather than in code.
+
+## Learn more
+
+- [Configuring the Catalog](/catalog/configuration) — display custom plans and control where they appear.
+- [Managing Company Plans](/catalog/managing-company-plans) — assign a plan to a specific company.
+- [Company Overrides](/feature-management/overrides) — adjust individual entitlements on top of a plan.

--- a/fern/docs/pages/use-cases/custom-deals.mdx
+++ b/fern/docs/pages/use-cases/custom-deals.mdx
@@ -8,7 +8,9 @@ Sales-led deals rarely fit neatly into the good-better-best plans on your pricin
 
 ## Common approaches
 
-Teams add one-off flags or special-case config in application code for each negotiated account. Over time that becomes a tangle of bespoke logic that's hard to audit, easy to break, and harder still to change when the customer renews on different terms.
+When a deal closes on non-standard terms, the fastest path is usually to add a one-off flag or a special-case config in application code for that account, hard-coding the extra seats, the custom limit, or the feature that isn't in any standard plan. For the first few enterprise deals this feels reasonable and ships quickly.
+
+But each bespoke account adds another branch of logic that only applies to one customer, and there's no single place to see what a given company was actually sold. The terms live in code rather than in your catalog, so auditing what's been promised is hard, changing it at renewal is risky, and the person who negotiated the deal can't adjust it without an engineer. Multiply that across a growing book of custom contracts and it becomes a real maintenance and compliance burden.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/customer-portal.mdx
+++ b/fern/docs/pages/use-cases/customer-portal.mdx
@@ -1,0 +1,22 @@
+---
+title: Give customers a self-service portal
+slug: use-cases/customer-portal
+description: One branded place for customers to manage subscriptions, payment, invoices, and usage.
+---
+
+Once customers are paying, they still need to manage their subscription: change plans, update a card, pull an invoice, or check how much of their plan they've used. Every one of those that turns into a support ticket is cost for you and friction for them.
+
+## Common approaches
+
+A common setup sends customers to Stripe's billing portal for invoices and payment, then builds separate in-app screens for plan changes and usage. The experience is split across surfaces, and the in-app pieces tend to drift out of sync with what billing actually reflects.
+
+## How Schematic fits in
+
+Schematic's customer portal gives customers one branded place to upgrade, downgrade, cancel, manage add-ons, view invoices and payment methods, and watch usage against their limits. Changes sync to Stripe and update entitlements immediately, so access always matches billing. You control which elements appear and how the portal looks in the component builder, no code deploy required.
+
+## Learn more
+
+- [Customer Portal and Checkout Flow](/components/customer-portal) — what the portal covers and how it works with Stripe.
+- [Create a Component](/components/create-component) — build and configure the portal in the component builder.
+- [Add to Your App](/components/set-up) — embed the portal in React, Vue, or plain JS.
+- [Building Your Own Portal](/components/headless-customer-portal) — go headless when you need full control of the UI.

--- a/fern/docs/pages/use-cases/customer-portal.mdx
+++ b/fern/docs/pages/use-cases/customer-portal.mdx
@@ -8,7 +8,9 @@ Once customers are paying, they still need to manage their subscription: change 
 
 ## Common approaches
 
-A common setup sends customers to Stripe's billing portal for invoices and payment, then builds separate in-app screens for plan changes and usage. The experience is split across surfaces, and the in-app pieces tend to drift out of sync with what billing actually reflects.
+A common setup sends customers to Stripe's billing portal for invoices and payment methods, then builds separate in-app screens for the things Stripe doesn't know about, like plan changes, add-ons, and usage against limits. Each surface handles part of the job, so the customer bounces between your product and a Stripe-branded page to manage one subscription.
+
+That split is also a maintenance burden. The in-app screens have to be kept consistent with billing, so a plan change made in your UI and a payment-method update made in Stripe's portal can momentarily disagree, and usage shown in-app may not match what's actually being invoiced. As you add plans, add-ons, and usage-based features, every one of these home-grown screens needs to keep up.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/expand-accounts.mdx
+++ b/fern/docs/pages/use-cases/expand-accounts.mdx
@@ -1,0 +1,24 @@
+---
+title: Expand accounts with upsells and add-ons
+slug: use-cases/expand-accounts
+description: Grow existing accounts with seats, add-ons, and tier upgrades.
+---
+
+Some of your best revenue comes from accounts you already have. Growing them means adding seats, selling add-ons, or moving a customer up a tier, ideally as a smooth motion rather than a custom project each time.
+
+## Common approaches
+
+Teams often handle expansion as a series of one-off changes: editing a subscription directly in Stripe, manually bumping a seat count, or adding a line item when a customer asks. For a handful of accounts this is perfectly workable, usually a quick task for sales or support.
+
+Handled by hand, though, expansion neither scales nor compounds. There's no consistent place for customers to add what they want themselves, changes made straight in billing can fall out of sync with the access your product actually grants, and every add-on or seat upgrade needs its own manual provisioning. The motion that should be your easiest revenue ends up gated on someone remembering to make the same change in two systems.
+
+## How Schematic fits in
+
+Model add-ons and seat-based entitlements in your catalog once, then let customers add them through the customer portal or have your team assign them to a company directly. Add-ons and seat counts map to Stripe products, so an expansion updates billing and entitlements together and the new access takes effect immediately. Pay-in-advance pricing lets customers buy seats or capacity in defined chunks as they grow.
+
+## Learn more
+
+- [Add Ons](/catalog/add-ons) — package extra features or capacity on top of a plan.
+- [Customer Portal and Checkout Flow](/components/customer-portal) — let customers add seats and add-ons themselves.
+- [Managing Company Plans](/catalog/managing-company-plans) — assign add-ons and plan changes to a specific company.
+- [Usage Based Billing Models](/billing/usage-based-billing) — sell seats and capacity with pay-in-advance pricing.

--- a/fern/docs/pages/use-cases/free-trials.mdx
+++ b/fern/docs/pages/use-cases/free-trials.mdx
@@ -1,0 +1,20 @@
+---
+title: Run free trials
+slug: use-cases/free-trials
+description: Grant time-limited access and convert trial users cleanly when the trial ends.
+---
+
+Letting prospects try a paid plan before they commit is one of the most reliable ways to convert them, but only if access is granted cleanly for the trial window and handled correctly the moment it ends.
+
+## Common approaches
+
+Teams often hard-code a trial flag with an expiry date, then write logic to grant premium access during the window and remember to revoke it afterward. The edge cases pile up fast: whether a card is required, which plan the customer lands on after the trial, and how to surface trial state in the product.
+
+## How Schematic fits in
+
+Turn on a trial when you create or edit a plan, and Schematic grants that plan's entitlements for the trial period automatically the first time a company is assigned it. In catalog configuration you decide whether payment is required up front, in which case the customer converts to the paid plan automatically, or not, in which case they downgrade to your default plan. The React and Vue SDKs expose trial status and end date, so you can render countdowns and post-trial conversion prompts without extra API calls.
+
+## Learn more
+
+- [Trials](/catalog/trials) — configure trials on a plan and render trial state in your app.
+- [Configuring the Catalog](/catalog/configuration) — set trial rules, including whether payment is required up front.

--- a/fern/docs/pages/use-cases/free-trials.mdx
+++ b/fern/docs/pages/use-cases/free-trials.mdx
@@ -8,7 +8,9 @@ Letting prospects try a paid plan before they commit is one of the most reliable
 
 ## Common approaches
 
-Teams often hard-code a trial flag with an expiry date, then write logic to grant premium access during the window and remember to revoke it afterward. The edge cases pile up fast: whether a card is required, which plan the customer lands on after the trial, and how to surface trial state in the product.
+Teams often hard-code a trial flag with an expiry date, then write logic to grant premium access during the window and revoke it when the clock runs out. It looks simple at first: set a date, check it on each request, and turn the features off when the trial ends.
+
+The edge cases pile up quickly, though. Whether a card is required up front changes what should happen at expiry, convert to paid automatically, or drop to a free tier, and each path needs its own handling. You also have to decide which plan the customer lands on afterward, make sure a trial only applies the first time, and surface trial state in the product so users see how long they have left. Each of these is easy to get subtly wrong, and a missed revocation means customers keep paid access for free.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/overrides.mdx
+++ b/fern/docs/pages/use-cases/overrides.mdx
@@ -8,7 +8,9 @@ Individual customers routinely need access that differs from their plan: a goodw
 
 ## Common approaches
 
-The usual fix is to special-case the customer in application code, or quietly move them onto a different plan. Both obscure why the exception exists, are easy to forget to reverse, and make it hard for customer success to see or manage what a given account actually has.
+The usual fix is to special-case the customer in application code, or to quietly move them onto a different plan that happens to include what they need. Either one resolves the immediate request, so it's tempting to reach for them whenever a one-off comes up.
+
+Both approaches hide the reason the exception exists. A flag buried in code or an off-catalog plan assignment doesn't record that this was a 30-day goodwill grant or a trial tied to an open opportunity, so there's nothing to reverse it when the time is up and nothing to point to when someone asks why this account has access it shouldn't. Customer success can't see or adjust these exceptions without engineering, and over time the accumulated special cases make it genuinely hard to know who has what.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/overrides.mdx
+++ b/fern/docs/pages/use-cases/overrides.mdx
@@ -1,0 +1,20 @@
+---
+title: Manage exceptions with overrides
+slug: use-cases/overrides
+description: Adjust a single company's access for trials, goodwill, or in-flight deals.
+---
+
+Individual customers routinely need access that differs from their plan: a goodwill bump after an outage, a temporary trial of a premium feature, or an exception while a deal closes, all without changing the underlying plan.
+
+## Common approaches
+
+The usual fix is to special-case the customer in application code, or quietly move them onto a different plan. Both obscure why the exception exists, are easy to forget to reverse, and make it hard for customer success to see or manage what a given account actually has.
+
+## How Schematic fits in
+
+Apply a company override from the Schematic UI or API to grant or adjust a single company's access to a feature. Overrides can carry an expiration date for time-limited trials, are visible and auditable right on the company, and follow a most-generous policy, so an override never accidentally reduces what a customer's plan already grants. Customer success can manage exceptions without an engineering ticket.
+
+## Learn more
+
+- [Company Overrides](/feature-management/overrides) — apply and manage overrides in the UI and via the API.
+- [Handling customer exceptions and feature trials](/playbooks/exceptions) — a step-by-step playbook, including time-limited overrides.

--- a/fern/docs/pages/use-cases/overview.mdx
+++ b/fern/docs/pages/use-cases/overview.mdx
@@ -20,10 +20,14 @@ These use cases cover the things teams most often want to do. Each one explains 
 ## Sales-led growth
 
 - **[Close custom deals](/use-cases/custom-deals)** — package bespoke pricing and entitlements for negotiated contracts without touching code.
+- **[Run sales-assisted trials and POCs](/use-cases/sales-assisted-trials)** — grant a time-boxed, scoped evaluation tied to an open opportunity.
+- **[Expand accounts with upsells and add-ons](/use-cases/expand-accounts)** — grow existing accounts with seats, add-ons, and tier upgrades.
 
 ## Customer management
 
 - **[Manage exceptions with overrides](/use-cases/overrides)** — adjust a single company's access for trials, goodwill, or in-flight deals.
+- **[Spot churn and expansion with usage signals](/use-cases/usage-signals)** — watch usage against entitlements to flag at-risk and upsell-ready accounts.
+- **[Stay ahead of renewals and expirations](/use-cases/renewals)** — catch trials, overrides, and contracts before they lapse and access changes.
 
 ## Operations
 

--- a/fern/docs/pages/use-cases/overview.mdx
+++ b/fern/docs/pages/use-cases/overview.mdx
@@ -1,0 +1,32 @@
+---
+title: Use Cases
+slug: use-cases/overview
+description: The common things teams build with Schematic, and where to start with each.
+---
+
+Schematic gives product, growth, and engineering teams one place to define what customers get, enforce it in real time, and bill for it, without hard-coding pricing and access into your application.
+
+These use cases cover the things teams most often want to do. Each one explains the goal, how it's usually approached, and how Schematic fits in, then points you to the deeper setup docs. New to Schematic? Start with the [Quickstart](/quickstart/overview) to set up your account and SDK first.
+
+## Product-led growth
+
+- **[Convert and expand users self-serve](/use-cases/self-serve-checkout)** — let customers sign up, upgrade, and add capacity without talking to sales.
+- **[Give customers a self-service portal](/use-cases/customer-portal)** — one branded place to manage subscriptions, payment, invoices, and usage.
+- **[Run free trials](/use-cases/free-trials)** — grant time-limited access and convert trial users cleanly when the trial ends.
+- **[Price by usage](/use-cases/usage-based-pricing)** — meter consumption, enforce limits, and turn rising usage into expansion.
+- **[Bill for usage](/use-cases/usage-billing)** — turn metered usage into accurate Stripe invoices automatically.
+- **[Run credit-based billing](/use-cases/credit-billing)** — sell a prepaid credit balance that burns down as customers use features.
+
+## Sales-led growth
+
+- **[Close custom deals](/use-cases/custom-deals)** — package bespoke pricing and entitlements for negotiated contracts without touching code.
+
+## Customer management
+
+- **[Manage exceptions with overrides](/use-cases/overrides)** — adjust a single company's access for trials, goodwill, or in-flight deals.
+
+## Operations
+
+- **[Reprice and repackage safely](/use-cases/plan-versioning)** — roll out new pricing and packaging and migrate customers on your terms.
+- **[Keep Stripe in sync](/use-cases/stripe-sync)** — keep entitlements and billing aligned through a bidirectional Stripe sync.
+- **[Automate with webhooks and AI](/use-cases/automation)** — drive Slack, CRM, and AI-assisted workflows off Schematic events.

--- a/fern/docs/pages/use-cases/plan-versioning.mdx
+++ b/fern/docs/pages/use-cases/plan-versioning.mdx
@@ -8,7 +8,9 @@ Pricing and packaging change as your product grows. The hard part isn't deciding
 
 ## Common approaches
 
-Teams edit plans in place and hope nothing breaks for current subscribers, or maintain parallel "legacy" plans by hand and migrate accounts one at a time. Both make it easy to grandfather customers inconsistently, or to apply a change you didn't mean to apply to everyone.
+One approach is to edit the plan in place, changing its price or entitlements directly and hoping nothing breaks for the customers currently on it. The other is to leave the old plan alone, create a new "v2" alongside it, and move accounts over by hand. Both are common, and both seem reasonable until you're partway through.
+
+Editing in place means a change intended for new customers can silently alter what existing subscribers already pay for or have access to. Maintaining parallel plans avoids that but creates a different mess: a growing list of near-duplicate plans, manual migrations that are easy to start and easy to abandon, and no clear record of who is grandfathered on what. In either case it's hard to answer a basic question, which customers are on which version, and even harder to roll a change out gradually with confidence.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/plan-versioning.mdx
+++ b/fern/docs/pages/use-cases/plan-versioning.mdx
@@ -1,0 +1,20 @@
+---
+title: Reprice and repackage safely
+slug: use-cases/plan-versioning
+description: Roll out new pricing and packaging and migrate customers on your terms.
+---
+
+Pricing and packaging change as your product grows. The hard part isn't deciding on the new structure, it's rolling it out without disrupting existing customers or losing track of who is on which version.
+
+## Common approaches
+
+Teams edit plans in place and hope nothing breaks for current subscribers, or maintain parallel "legacy" plans by hand and migrate accounts one at a time. Both make it easy to grandfather customers inconsistently, or to apply a change you didn't mean to apply to everyone.
+
+## How Schematic fits in
+
+Every edit to a plan becomes a new draft version that you publish when you're ready. At publish time, you decide how current subscribers are handled: migrate all of them, choose specific companies, or keep them on their existing version. You can track migration progress per plan, so you always know exactly who is on which version and nobody moves until you say so.
+
+## Learn more
+
+- [Rolling Out New Plan Versions](/catalog/guides/plan-versions) — the full publish-and-migrate flow.
+- [Plans](/catalog/plans) — how plan versions and drafts work.

--- a/fern/docs/pages/use-cases/renewals.mdx
+++ b/fern/docs/pages/use-cases/renewals.mdx
@@ -1,0 +1,24 @@
+---
+title: Stay ahead of renewals and expirations
+slug: use-cases/renewals
+description: Catch trials, overrides, and contracts before they lapse and access changes.
+---
+
+A lot of access in Schematic is time-bound: trials end, overrides expire, and annual contracts come up for renewal. Each of those is a moment when a customer's access is about to change, and catching it early is the difference between a smooth renewal and a surprised, churned customer.
+
+## Common approaches
+
+Expirations tend to get tracked in scattered places: a spreadsheet of contract dates, a calendar reminder for a trial, a note in the CRM, each maintained by hand. It works as long as someone keeps every list current and remembers to check them on time.
+
+In practice, those lists drift and reminders slip. A trial lapses with no conversion nudge, an override quietly expires and a customer loses a feature they assumed they had, or a renewal sneaks up with no lead time to engage the account. Because the dates live apart from the system that actually enforces access, nothing reliably connects "this is about to expire" to "someone should do something about it."
+
+## How Schematic fits in
+
+Time-bound access in Schematic carries its expiration with it: trials have an end date and defined conversion behavior, overrides can be set to expire, and subscription status reflects where a customer is in their lifecycle. You can surface trial countdowns in-product, configure what happens when a trial ends, convert to paid or fall back to a default plan, and use webhooks to alert your team ahead of a lapse so the renewal or conversion conversation happens before access changes.
+
+## Learn more
+
+- [Trials](/catalog/trials) — trial end dates, conversion, and rendering trial state in your app.
+- [Company Overrides](/feature-management/overrides) — set overrides to expire on a date.
+- [Configuring the Catalog](/catalog/configuration) — set trial expiry behavior and fallback plans.
+- [Webhooks](/integrations/webhooks) — alert your team ahead of an expiration.

--- a/fern/docs/pages/use-cases/sales-assisted-trials.mdx
+++ b/fern/docs/pages/use-cases/sales-assisted-trials.mdx
@@ -1,0 +1,23 @@
+---
+title: Run sales-assisted trials and POCs
+slug: use-cases/sales-assisted-trials
+description: Grant a time-boxed, scoped evaluation tied to an open opportunity.
+---
+
+Enterprise deals often hinge on a proof of concept: a defined window where a prospect gets access to evaluate the product against their own use case. The eval needs to start quickly, match what sales scoped, and wind down cleanly when it ends.
+
+## Common approaches
+
+Under deal pressure, the usual move is for sales to ask engineering to "just turn it on" for the prospect, which in practice means a hard-coded flag or a temporary plan bump applied to that one account. It unblocks the evaluation immediately, so it tends to be the path of least resistance.
+
+The problem is that these grants are invisible and easy to forget. Nothing records that this access is a 30-day POC tied to a specific opportunity, so when the eval ends someone has to remember to undo it, and if they don't, the prospect keeps premium access for free. Scoping the trial to only the features under evaluation, or extending it when the deal slips a couple of weeks, means yet another round of manual code or config changes.
+
+## How Schematic fits in
+
+Grant the evaluation with a company override or a trial, scoped to exactly the features in play and set to expire at the end of the window. The grant is visible and auditable right on the company, customer-facing teams can set it up or extend it without engineering, and when it expires access reverts on its own. If the deal closes, you convert the prospect onto their negotiated plan rather than unwinding a pile of one-off flags.
+
+## Learn more
+
+- [Company Overrides](/feature-management/overrides) — grant scoped, time-limited access to a single company.
+- [Handling customer exceptions and feature trials](/playbooks/exceptions) — a playbook for time-limited grants.
+- [Trials](/catalog/trials) — plan-level trials with defined end dates and conversion behavior.

--- a/fern/docs/pages/use-cases/self-serve-checkout.mdx
+++ b/fern/docs/pages/use-cases/self-serve-checkout.mdx
@@ -1,0 +1,22 @@
+---
+title: Convert and expand users self-serve
+slug: use-cases/self-serve-checkout
+description: Let customers sign up, upgrade, and add capacity without talking to sales.
+---
+
+Plenty of buyers would rather pick a plan, pay, and start using your product than sit through a sales call. Capturing that revenue means showing the right plans, taking payment, and unlocking access the moment a customer pays, for first purchases and for every upgrade after.
+
+## Common approaches
+
+Teams often stand up a Stripe Checkout link or a static pricing page, then write webhook handlers to translate Stripe events back into in-app access. That can work for a first purchase, but upgrades, downgrades, add-ons, and proration each need more glue code, and the pricing page drifts out of sync with what you actually sell.
+
+## How Schematic fits in
+
+Drop in Schematic's pricing table and checkout components. They render your live plans straight from the catalog, run the full purchase, upgrade, downgrade, and add-on flow on top of Stripe, and provision entitlements the instant checkout completes, with no webhook mapping to maintain. When you change pricing or restructure plans in Schematic, the checkout UI updates without a deploy.
+
+## Learn more
+
+- [Pricing Table](/components/pricing-table) — the public-facing plan and pricing component.
+- [Customer Portal and Checkout Flow](/components/customer-portal) — the full checkout and subscription-management experience.
+- [Standalone Components](/components/standalone-components) — lightweight components for public pricing pages.
+- [Quickstart](/quickstart/overview) — set up your account, plans, and SDK first.

--- a/fern/docs/pages/use-cases/self-serve-checkout.mdx
+++ b/fern/docs/pages/use-cases/self-serve-checkout.mdx
@@ -8,7 +8,9 @@ Plenty of buyers would rather pick a plan, pay, and start using your product tha
 
 ## Common approaches
 
-Teams often stand up a Stripe Checkout link or a static pricing page, then write webhook handlers to translate Stripe events back into in-app access. That can work for a first purchase, but upgrades, downgrades, add-ons, and proration each need more glue code, and the pricing page drifts out of sync with what you actually sell.
+Most teams start by standing up a Stripe Checkout link or a static pricing page and wiring it to a few webhook handlers that translate Stripe events back into in-app access. For a single, first-time purchase that gets the job done: the customer pays, a webhook fires, and you flip on the features they bought.
+
+The trouble starts after that first sale. Upgrades, downgrades, add-ons, and mid-cycle proration each introduce new Stripe events and new edge cases, so the handler code grows and the access logic gets harder to reason about. Meanwhile the pricing page is maintained separately from what you actually sell, so every packaging change means touching the page, the checkout, and the entitlement mapping in lockstep, and any one of them drifting out of sync shows up as a customer who paid but can't access what they bought.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/stripe-sync.mdx
+++ b/fern/docs/pages/use-cases/stripe-sync.mdx
@@ -8,7 +8,9 @@ Your product enforces access in real time, but billing lives in Stripe, and the 
 
 ## Common approaches
 
-Teams write and maintain webhook handlers in both directions: mapping Stripe events to in-app entitlements, and pushing app-side changes back to Stripe. That integration layer is significant to build, and it tends to break as the catalog grows and new plans, add-ons, and usage products are introduced.
+The do-it-yourself version is a two-way integration. In one direction you listen for Stripe webhooks, subscription created, updated, canceled, payment failed, and translate each into the right entitlement changes in your app. In the other, you push changes made in your product, an upgrade, an added seat, a cancellation, back to Stripe so billing reflects them.
+
+Getting that integration correct is a real project, and keeping it correct is the harder part. Every new plan, add-on, or usage-based product is another mapping to maintain, and subscription lifecycle states like past-due, paused, or incomplete each need a deliberate decision about whether access should continue. Miss one of those edge cases and the two systems quietly disagree, so a customer keeps access after canceling, or loses it after a payment that actually succeeded.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/stripe-sync.mdx
+++ b/fern/docs/pages/use-cases/stripe-sync.mdx
@@ -1,0 +1,22 @@
+---
+title: Keep Stripe in sync
+slug: use-cases/stripe-sync
+description: Keep entitlements and billing aligned through a bidirectional Stripe sync.
+---
+
+Your product enforces access in real time, but billing lives in Stripe, and the two have to agree. When a subscription, plan, add-on, or quantity changes, both your app and Stripe need to reflect it, without anyone updating records by hand.
+
+## Common approaches
+
+Teams write and maintain webhook handlers in both directions: mapping Stripe events to in-app entitlements, and pushing app-side changes back to Stripe. That integration layer is significant to build, and it tends to break as the catalog grows and new plans, add-ons, and usage products are introduced.
+
+## How Schematic fits in
+
+Schematic runs a bidirectional sync with Stripe. Map plans and add-ons to Stripe products and usage features to metered products; changes made through Schematic checkout and the customer portal write straight to Stripe, while subscription changes in Stripe provision or revoke entitlements automatically. Subscription status drives access, so cancellations and failed payments move customers to the right state without custom code.
+
+## Learn more
+
+- [Stripe Integration](/integrations/stripe) — how the bidirectional sync works end to end.
+- [Stripe Integration Guide](/integrations/stripe-integration-guide) — mapping companies, plans, and prices correctly.
+- [Stripe App](/integrations/stripe-app) — manage Schematic from inside the Stripe dashboard.
+- [Automatically provision customers using Stripe](/playbooks/provisioning) — a playbook for provisioning from subscriptions.

--- a/fern/docs/pages/use-cases/usage-based-pricing.mdx
+++ b/fern/docs/pages/use-cases/usage-based-pricing.mdx
@@ -1,0 +1,21 @@
+---
+title: Price by usage
+slug: use-cases/usage-based-pricing
+description: Meter consumption, enforce limits, and turn rising usage into expansion.
+---
+
+Some products get more valuable the more they're used. Pricing that way means metering consumption accurately, enforcing limits as customers reach them, and turning that usage into upgrades and expansion revenue.
+
+## Common approaches
+
+Teams log usage to their own database, run jobs to tally it, and hand-roll limit checks throughout the app. It holds together until plans change, limits vary by customer, or that usage needs to drive an upgrade or an invoice, at which point the homegrown metering becomes its own product to maintain.
+
+## How Schematic fits in
+
+Define a metered feature (event-based for things like API calls, trait-based for things like seats), set entitlement limits per plan, and report usage. Schematic enforces access at runtime as customers approach their limits and supports a range of models, pay-as-you-go, pay-in-advance, fixed fee with overage, volume, and graduated pricing, so you can match how you want to charge without rebuilding metering each time.
+
+## Learn more
+
+- [Usage Based Billing Models](/billing/usage-based-billing) — the supported pricing models and how to configure each.
+- [Creating a metered feature](/playbooks/metering) — step-by-step setup for event- and trait-based features.
+- [Tracking Feature Usage](/feature-management/feature-analytics) — recording the events and traits that power metering.

--- a/fern/docs/pages/use-cases/usage-based-pricing.mdx
+++ b/fern/docs/pages/use-cases/usage-based-pricing.mdx
@@ -8,7 +8,9 @@ Some products get more valuable the more they're used. Pricing that way means me
 
 ## Common approaches
 
-Teams log usage to their own database, run jobs to tally it, and hand-roll limit checks throughout the app. It holds together until plans change, limits vary by customer, or that usage needs to drive an upgrade or an invoice, at which point the homegrown metering becomes its own product to maintain.
+Teams usually start by logging usage to their own database, running scheduled jobs to tally it up, and scattering limit checks throughout the application code. For a single metered feature with one global limit, that's manageable, and many products ship their first usage-based feature exactly this way.
+
+It stops scaling as soon as the pricing gets real. Limits that vary by plan or by customer, periods that reset on each customer's billing date, soft limits with overage, and the need to show usage-versus-limit in the UI all turn the homegrown meter into its own system to build and maintain. And tallying usage for your own enforcement is only half the work, getting those same numbers onto an accurate invoice means reconciling your counts against the billing system, which is where the home-grown approach tends to break down.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/usage-billing.mdx
+++ b/fern/docs/pages/use-cases/usage-billing.mdx
@@ -1,0 +1,21 @@
+---
+title: Bill for usage
+slug: use-cases/usage-billing
+description: Turn metered usage into accurate Stripe invoices automatically.
+---
+
+Metering usage is only half the job. The consumption you measure has to land on an accurate invoice, every billing period, without a manual reconciliation at month-end.
+
+## Common approaches
+
+Teams export usage from their own system, reconcile it against active subscriptions, and push quantities into Stripe by hand or with a custom job. It's error-prone, hard to audit when a customer questions a charge, and a recurring scramble at the close of every billing period.
+
+## How Schematic fits in
+
+Map a usage-based feature to a Stripe metered product, and Schematic reports billable usage to Stripe in real time, reflected consistently in your app, the Schematic dashboard, and Stripe. Choose the billing model per entitlement, pay-as-you-go, fixed fee with overage, volume, or graduated, and use negative-quantity events for refunds and corrections. Stripe stays the source of truth for invoicing; Schematic keeps the quantities accurate.
+
+## Learn more
+
+- [Usage Based Billing Models](/billing/usage-based-billing) — configure how usage maps to charges.
+- [Stripe Integration](/integrations/stripe) — how usage features map to Stripe metered products.
+- [Stripe Integration Guide](/integrations/stripe-integration-guide) — the technical setup for mapping and syncing.

--- a/fern/docs/pages/use-cases/usage-billing.mdx
+++ b/fern/docs/pages/use-cases/usage-billing.mdx
@@ -8,7 +8,9 @@ Metering usage is only half the job. The consumption you measure has to land on 
 
 ## Common approaches
 
-Teams export usage from their own system, reconcile it against active subscriptions, and push quantities into Stripe by hand or with a custom job. It's error-prone, hard to audit when a customer questions a charge, and a recurring scramble at the close of every billing period.
+Teams typically export usage from their own system at the end of each period, reconcile it against active subscriptions, and push the resulting quantities into Stripe, either by hand or with a custom job built for the purpose. The mechanics aren't complicated for one feature and a handful of customers, so it often starts as a quick monthly script.
+
+The problem is that this runs on a deadline, every billing period, with money on the line. A misaligned period boundary, a customer who upgraded mid-cycle, or a timezone mismatch quietly produces a wrong invoice, and when a customer questions a charge there's no easy trail back to the underlying events. As the customer base and the number of metered features grow, the month-end reconciliation becomes a recurring scramble that's both error-prone and hard to audit.
 
 ## How Schematic fits in
 

--- a/fern/docs/pages/use-cases/usage-signals.mdx
+++ b/fern/docs/pages/use-cases/usage-signals.mdx
@@ -1,0 +1,23 @@
+---
+title: Spot churn and expansion with usage signals
+slug: use-cases/usage-signals
+description: Watch usage against entitlements to flag at-risk and upsell-ready accounts.
+---
+
+How much a customer uses your product is the clearest early signal of whether they'll churn or expand. Acting on it means seeing each account's usage against what they're entitled to, and catching the accounts trending the wrong way, or pressing against their limits, before a renewal comes up.
+
+## Common approaches
+
+Teams usually piece this together from a few sources: a BI dashboard built on raw product events, exports pulled together for quarterly reviews, or a gut feel from the last handful of support tickets. When someone goes looking for a specific answer, this can provide it.
+
+Disconnected from entitlements, though, raw usage only tells half the story. A usage number is a churn or expansion signal only relative to what the customer is entitled to and paying for, and stitching usage data back to plan limits in a separate tool is manual and goes stale fast. By the time a report surfaces an at-risk account or one consistently hitting its ceiling, the renewal or upsell window may already have closed.
+
+## How Schematic fits in
+
+Schematic tracks each company's usage against its entitlements in one place, so customer success can see who's underusing, a churn risk, and who's pressing against their limits, an expansion opportunity. Entitlement and credit trigger webhooks let you fire alerts or in-app prompts the moment an account crosses a threshold, so the signal reaches the right person while there's still time to act on it.
+
+## Learn more
+
+- [Tracking Feature Usage](/feature-management/feature-analytics) — view usage against entitlements per company.
+- [Entitlement & Credit Trigger Webhooks](/integrations/webhooks/entitlement-triggers) — fire on usage and limit thresholds.
+- [Webhooks](/integrations/webhooks) — route those signals to Slack, your CRM, or any endpoint.


### PR DESCRIPTION
## What

Adds a new **Use Cases** docs section: a business-outcome-framed layer that lays out the common things teams build with Schematic and links into the existing technical docs and playbooks. Layout inspired by Nango's use-case pages.

## Structure

Index (`use-cases/overview.mdx`) + 11 pages grouped into four categories:

- **Product-Led Growth** — Convert and expand users self-serve · Self-service portal · Free trials · Price by usage · Bill for usage · Credit-based billing
- **Sales-Led Growth** — Close custom deals
- **Customer Management** — Manage exceptions with overrides
- **Operations** — Reprice and repackage safely (plan versioning) · Keep Stripe in sync · Automate with webhooks and AI

Each page uses a consistent skeleton: the *need* (unheadered intro) → **Common approaches** → **How Schematic fits in** → **Learn more**. Pages are deliberately light and link out; deeper technical guides are a later pass.

## Nav

`fern/docs.yml`: new **Use Cases** section inserted after "Using Schematic", and **Playbooks** moved up to follow it. Playbooks content is unchanged; Use Cases link into it.

## Validation

- `fern check`: **0 errors**. The pre-existing 50 warnings don't reference the new pages.
- All "Learn more" links verified against live page slugs.

## Notes for review

- **Playbooks placement** is a judgment call (currently between Use Cases and Quickstart) — easy to move.
- PLG is intentionally the heavy bucket; Customer Management is lean for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)