### PR TITLE
chore: bump python generator to 5.14.20 (major)

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "schematic",
-  "version": "5.6.0"
+  "version": "5.50.0"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -19,7 +19,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.64.1
+        version: 5.14.20
         output:
           location: pypi
           package-name: schematichq


### PR DESCRIPTION
Major bump of `fern-python-sdk` 4.64.1 → 5.14.20 to resolve the pytest tmpdir vuln Dependabot flagged in schematic-python ([alert #3](https://github.com/SchematicHQ/schematic-python/security/dependabot/3)).

That vuln can only be fixed upstream at the generator — the `pytest = "^7.4.0"` pin lives in the generator's `pyproject.toml` template, so Dependabot bumps get overwritten on the next `fern generate`. Verified via a local `fern generate --local` run that the new generator emits `pytest = "^9.0.3"` (≥ the patched 9.0.3).

Also bumps the fern CLI 5.6.0 → 5.50.0, required by the new generator (refuses to run on CLI < 5.44.6).

Since this is a 4.x→5.x generator jump, the regenerated schematic-python PR may carry more than the pytest pin — review its diff and CI before merging.