### PR TITLE
Fix credit balance hook docs to match SDK signatures

### DIFF
--- a/fern/docs/pages/developer_resources/sdks/angular.mdx
+++ b/fern/docs/pages/developer_resources/sdks/angular.mdx
@@ -269,7 +269,7 @@ export class CreditMeterComponent {
 | `balance` | `number` | The spendable balance, or `0` while loading or when the company holds no balance in this credit |
 | `isLoading` | `boolean` | `true` while the balance is still loading and no value has arrived yet |
 
-By default it surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, pass a second argument (`"remaining"` or `"reserved"`) to surface those values instead. The credit ID is available on a feature's entitlement: `entitlement$(key)` emits `creditId` for credit-based features.
+It surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, read the underlying client instead: `getClient().getCreditBalance(creditId)` returns all three views of the balance — `settled`, `remaining` (excluding open lease holds), and `reserved` (the amount held by open leases) — as a point-in-time snapshot; subscribe with `getClient().addCreditBalanceListener(callback)` to react to changes. The credit ID is available on a feature's entitlement: `entitlement$(key)` emits `creditId` for credit-based features.
 
 *Note: `creditBalance$` requires `@schematichq/schematic-angular` 1.5.0 or later.*
 
@@ -292,7 +292,7 @@ Injectable service providing all Schematic functionality:
 | `flagValue$(key, fallback?)` | `Observable<boolean>` | Observe a feature flag's boolean value |
 | `entitlement$(key, fallback?)` | `Observable<CheckFlagReturn>` | Observe detailed entitlement data |
 | `plan$()` | `Observable<CheckPlanReturn \| undefined>` | Observe plan information |
-| `creditBalance$(creditId, type?)` | `Observable<SchematicCreditBalance>` | Observe a company's lease-aware credit balance |
+| `creditBalance$(creditId)` | `Observable<SchematicCreditBalance>` | Observe a company's lease-aware credit balance |
 | `isPending$()` | `Observable<boolean>` | Observe loading state |
 
 ### `SCHEMATIC_CLIENT`

--- a/fern/docs/pages/developer_resources/sdks/react.mdx
+++ b/fern/docs/pages/developer_resources/sdks/react.mdx
@@ -204,11 +204,16 @@ The hook returns an object with the following properties:
 | `balance` | `number` | The spendable balance, or `0` while loading or when the company holds no balance in this credit |
 | `isLoading` | `boolean` | `true` while the balance is still loading and no value has arrived yet |
 
-By default the hook surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, pass `opts.type` as `"remaining"` or `"reserved"` to surface those values instead:
+The hook surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, read the underlying client instead: `client.getCreditBalance(creditId)` returns all three views of the balance — `settled`, `remaining` (excluding open lease holds), and `reserved` (the amount held by open leases):
 
 ```tsx
-const { balance } = useSchematicCreditBalance("credit-id", { type: "reserved" });
+import { useSchematic } from "@schematichq/schematic-react";
+
+const { client } = useSchematic();
+const balance = client.getCreditBalance("credit-id"); // { settled, remaining, reserved } | undefined
 ```
+
+`getCreditBalance` returns a point-in-time snapshot; to react to changes, subscribe with `client.addCreditBalanceListener(callback)`.
 
 The credit ID is available on a feature's entitlement: `useSchematicEntitlement(key)` returns `creditId` for credit-based features.
 

--- a/fern/docs/pages/developer_resources/sdks/vue.mdx
+++ b/fern/docs/pages/developer_resources/sdks/vue.mdx
@@ -201,11 +201,16 @@ The composable returns an object with the following reactive properties:
 | `balance` | `ComputedRef<number>` | The spendable balance, or `0` while loading or when the company holds no balance in this credit |
 | `isLoading` | `ComputedRef<boolean>` | `true` while the balance is still loading and no value has arrived yet |
 
-By default the composable surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, pass `opts.type` as `"remaining"` or `"reserved"` to surface those values instead:
+The composable surfaces the `settled` balance, which is the spendable number you should show end users. For advanced lease-aware accounting, read the underlying client instead: `client.getCreditBalance(creditId)` returns all three views of the balance — `settled`, `remaining` (excluding open lease holds), and `reserved` (the amount held by open leases):
 
 ```ts
-const { balance } = useSchematicCreditBalance("credit-id", { type: "reserved" });
+import { useSchematicClient } from "@schematichq/schematic-vue";
+
+const client = useSchematicClient();
+const balance = client.getCreditBalance("credit-id"); // { settled, remaining, reserved } | undefined
 ```
+
+`getCreditBalance` returns a point-in-time snapshot; to react to changes, subscribe with `client.addCreditBalanceListener(callback)`.
 
 The credit ID is available on a feature's entitlement: `useSchematicEntitlement(key)` returns `creditId` for credit-based features.
 


### PR DESCRIPTION
The React, Vue, and Angular SDK docs claimed a balance-type option (`opts.type: "remaining" | "reserved"` on the hook/composable, a second argument on Angular's `creditBalance$`) that the SDKs don't accept — verified against schematic-js source on main: `useSchematicCreditBalance(creditId, opts?)` returns `{ balance, isLoading }` (settled only), and `creditBalance$(creditId)` takes one argument. Replaces the nonexistent option with the real advanced path: the underlying client's `getCreditBalance(creditId)`, which returns `{ settled, remaining, reserved }`, plus `addCreditBalanceListener` for reactivity.