### PR TITLE
chore(docs): document auto.topup.success and credit.purchase.success webhooks

### DIFF
--- a/fern/docs/pages/integrations/webhooks-entitlement-triggers.mdx
+++ b/fern/docs/pages/integrations/webhooks-entitlement-triggers.mdx
@@ -60,16 +60,47 @@ Credit triggers fire based on credit usage:
 
 Credit triggers are configured per credit type, using a `credit_id` in the trigger config when creating or updating a webhook endpoint.
 
-## Auto-topup failure events
+## Credit purchase events
 
-These events fire when a scheduled credit auto-topup fails:
+This event fires when a company successfully purchases a credit bundle:
 
 | Event | When it fires |
 | --- | --- |
+| `credit.purchase.success` | A credit bundle purchase completes and the grants are committed |
+
+### Payload
+
+**`credit.purchase.success`** — typed as [`CreditsCreditPurchaseSuccess`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsCreditPurchaseSuccess.ts):
+
+| Field | Description |
+| --- | --- |
+| `bundleId` | ID of the purchased credit bundle |
+| `bundleName` | Name of the purchased credit bundle |
+| `company` | Summary of the purchasing company |
+| `credit` | Summary of the credit that was topped up |
+| `grantIds` | IDs of the credit grants created by the purchase |
+| `quantity` | Number of credits granted by the purchase |
+
+## Auto-topup events
+
+These events fire on the outcome of a scheduled credit auto-topup:
+
+| Event | When it fires |
+| --- | --- |
+| `auto.topup.success` | An auto-topup completes and the credits are granted |
 | `auto.topup.hard.failure` | An auto-topup attempt fails and will not be retried |
 | `auto.topup.retry.exceeded` | An auto-topup has failed too many consecutive times |
 
 ### Payload
+
+**`auto.topup.success`** — typed as [`CreditsAutoTopupSuccess`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsAutoTopupSuccess.ts):
+
+| Field | Description |
+| --- | --- |
+| `company` | Summary of the affected company |
+| `credit` | Summary of the credit that was topped up |
+| `grantId` | ID of the credit grant created by the top-up |
+| `quantity` | Number of credits granted by the top-up |
 
 **`auto.topup.hard.failure`** — typed as [`CreditsAutoTopupHardFailure`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsAutoTopupHardFailure.ts):
 

--- a/fern/docs/pages/integrations/webhooks.mdx
+++ b/fern/docs/pages/integrations/webhooks.mdx
@@ -42,8 +42,10 @@ The table below lists every supported event and links to its payload type in the
 | --- | --- |
 | `entitlement.limit.reached`, `entitlement.limit.warning`, `entitlement.soft_limit.reached`, `entitlement.soft_limit.warning`, `entitlement.tier_limit.reached`, `entitlement.tier_limit.warning` | [`WebFeatureUsageWebhookOutput`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/WebFeatureUsageWebhookOutput.ts) |
 | `credit.limit.reached`, `credit.limit.warning` | — |
+| `credit.purchase.success` | [`CreditsCreditPurchaseSuccess`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsCreditPurchaseSuccess.ts) |
 | `auto.topup.hard.failure` | [`CreditsAutoTopupHardFailure`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsAutoTopupHardFailure.ts) |
 | `auto.topup.retry.exceeded` | [`CreditsAutoTopupRetryFailure`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsAutoTopupRetryFailure.ts) |
+| `auto.topup.success` | [`CreditsAutoTopupSuccess`](https://github.com/SchematicHQ/schematic-node/blob/main/src/api/types/CreditsAutoTopupSuccess.ts) |
 
 ## Payload types
 


### PR DESCRIPTION
Documents the two webhook events added in schematic-api #6690 (`auto.topup.success`, `credit.purchase.success`). The webhooks pages are hand-maintained MDX, so they don't pick up new events automatically.

- `webhooks.mdx`: adds both events to the supported-events table.
- `webhooks-entitlement-triggers.mdx`: adds a Credit purchase events section with the `credit.purchase.success` payload, and renames "Auto-topup failure events" -> "Auto-topup events" to cover `auto.topup.success` alongside the failure events (anchor changes to #auto-topup-events; no inbound links found).

Blocked on SDK release: the type links point to `CreditsAutoTopupSuccess` / `CreditsCreditPurchaseSuccess` in schematic-node, which are not published yet. The API change merged 2026-07-21, one day after the 2026-07-20 SDK regen (v1.5.5), so it missed this week's Monday release. Hold merge until the next SDK regen (or an off-cycle one) so the links resolve.