### PR TITLE
document the hosted MCP server

### DIFF
--- a/fern/docs/pages/ai_tooling/for-developers.mdx
+++ b/fern/docs/pages/ai_tooling/for-developers.mdx
@@ -42,7 +42,7 @@ AI skills for Schematic Components help you integrate and customize UI component
 
 ## Model Context Protocol (MCP)
 
-Schematic's MCP server allows AI assistants to directly interact with your Schematic account through the Model Context Protocol. This enables AI tools to:
+Schematic hosts an MCP server at `https://api.schematichq.com/mcp`. Any MCP-compatible AI assistant can connect to it to interact with your Schematic account directly:
 
 - Query company information and plans
 - Check feature usage and entitlements
@@ -50,7 +50,7 @@ Schematic's MCP server allows AI assistants to directly interact with your Schem
 - Create and update features and plans
 - Analyze usage patterns
 
-The MCP server is part of the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=schematichq). Download and install insctructions can be found at [our MCP GitHub repository](https://github.com/schematicHQ/schematic-mcp). 
+There is nothing to install or run — the server is part of the Schematic API.
 
 ### Common Use Cases
 
@@ -61,19 +61,39 @@ The MCP integration is particularly useful for:
 - **Data analysis** - Use natural language queries to analyze usage patterns and customer data
 - **Plan management** - Let AI assistants help you create and modify plans based on your requirements
 
-### Getting Started with MCP
+### Connect with OAuth
 
-To use Schematic's MCP integration:
+Clients that support MCP OAuth (such as Claude) can connect with your Schematic user account — no API key needed.
 
-1. Install the Schematic MCP server from the [schematic-mcp repository](https://github.com/schematicHQ/schematic-mcp)
-2. Configure your MCP server with Schematic API credentials
-3. Connect your AI assistant to the MCP server
-4. Start using natural language queries to interact with Schematic
+In Claude, go to **Settings > Connectors > Add custom connector** and enter `https://api.schematichq.com/mcp` as the URL. When you connect, Schematic asks you to sign in, pick an environment, and choose read-only or read and write access. Write tools also respect your team member permissions: a grant can never do more than you can do in the Schematic app, and permission changes take effect immediately.
+
+In Claude Code:
+
+```bash
+claude mcp add --transport http schematic https://api.schematichq.com/mcp
+```
+
+Then run `/mcp` to sign in.
+
+### Connect with an API key
+
+Clients can also authenticate with a Schematic secret API key as a bearer token:
+
+```bash
+claude mcp add --transport http schematic https://api.schematichq.com/mcp \
+  --header "Authorization: Bearer your-secret-api-key"
+```
+
+Read-only API keys can use only the read tools.
 
 **Example MCP queries:**
 - "What plan is company Acme Corp on?"
 - "Show me feature usage for the 'api_calls' feature across all companies"
 - "Create a company override to enable 'beta_features' for company comp_123"
+
+<Note>
+The [schematic-mcp npm package](https://github.com/schematicHQ/schematic-mcp), a local stdio MCP server, is deprecated in favor of the hosted server. Existing installs keep working, but new setups should use the hosted server above.
+</Note>
 
 {/* 
 ## Claude Plugin

--- a/fern/docs/pages/ai_tooling/for-developers.mdx
+++ b/fern/docs/pages/ai_tooling/for-developers.mdx
@@ -89,10 +89,6 @@ Read-only API keys can use only the read tools.
 - "Show me feature usage for the 'api_calls' feature across all companies"
 - "Create a company override to enable 'beta_features' for company comp_123"
 
-<Note>
-The [schematic-mcp npm package](https://github.com/schematicHQ/schematic-mcp), a local stdio MCP server, is deprecated in favor of the hosted server. Existing installs keep working, but new setups should use the hosted server above.
-</Note>
-
 {/* 
 ## Claude Plugin
 

--- a/fern/docs/pages/ai_tooling/for-developers.mdx
+++ b/fern/docs/pages/ai_tooling/for-developers.mdx
@@ -50,8 +50,6 @@ Schematic hosts an MCP server at `https://api.schematichq.com/mcp`. Any MCP-comp
 - Create and update features and plans
 - Analyze usage patterns
 
-There is nothing to install or run — the server is part of the Schematic API.
-
 ### Common Use Cases
 
 The MCP integration is particularly useful for:


### PR DESCRIPTION
Rewrite the MCP section of the AI Tooling page for the hosted server at https://api.schematichq.com/mcp: OAuth and API-key connection instructions, plus a deprecation note for the npm stdio package. Anchor links from other pages are unchanged.