### PR TITLE
DEV-305: fix the Add Ons copy-paste bug in concepts.mdx

### DIFF
--- a/fern/docs/pages/get_started/concepts.mdx
+++ b/fern/docs/pages/get_started/concepts.mdx
@@ -50,9 +50,9 @@ When a new plan version is created, you can migrate all, some, or none of the cu
 
 ## Add Ons
 
-In Schematic, plans are versioned automatically, and updating an existing plan with subscribers will create a new version instead. Only the newest version of a plan is available to be subscribed to customers. This allows plans to be iterated on without effecting existing subscribers. This can be used for pricing changes and experiments.
+An **add on** is an optional module a company can purchase alongside its plan. A company has exactly one plan but can have any number of add ons, which are most often used to sell functionality that increases the value of a core plan.
 
-When a new plan version is created, you can migrate all, some, or none of the current subscribers to the new version.
+Add ons carry their own entitlements. An add on entitlement can introduce a feature the plan doesn't include, or override a limit the plan already sets. Like plans, add ons are versioned, but they're versioned independently of the base plan, so publishing a new add on version only affects companies that have that add on.
 
 ## Companies
 


### PR DESCRIPTION
The Add Ons section of the concepts page was a verbatim copy-paste of the Plan Versions section directly above it. Anyone looking up what an add on is got a description of plan versioning instead.

Replaced it with a real definition, summarized from `/catalog/add-ons`: what an add on is, that a company has exactly one plan but any number of add ons, how add on entitlements work, and that add ons version independently of the base plan.

Closes DEV-305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)