### PR TITLE
DEV-307: re-slug the 4 misleading /architecture/* pages

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -593,7 +593,6 @@ analytics:
 css: ./styles.css
 
 redirects:
-    # DEV-307: production readiness pages moved off the misleading /architecture/* prefix
   - source: "/architecture/security"
     destination: "/production_readiness/security"
     permanent: true

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -593,6 +593,19 @@ analytics:
 css: ./styles.css
 
 redirects:
+    # DEV-307: production readiness pages moved off the misleading /architecture/* prefix
+  - source: "/architecture/security"
+    destination: "/production_readiness/security"
+    permanent: true
+  - source: "/architecture/availability"
+    destination: "/production_readiness/availability"
+    permanent: true
+  - source: "/architecture/observability"
+    destination: "/production_readiness/observability"
+    permanent: true
+  - source: "/architecture/roles-and-permissions"
+    destination: "/production_readiness/roles-and-permissions"
+    permanent: true
   - source: "/introduction"
     destination: "/what-is-schematic"
     permanent: true
@@ -606,7 +619,7 @@ redirects:
     destination: "/feature-management/:slug"
     permanent: true
   - source: "/security"
-    destination: "/architecture/security"
+    destination: "/production_readiness/security"
     permanent: true
   - source: "/quickstart"
     destination: "/quickstart/overview"
@@ -624,7 +637,7 @@ redirects:
     destination: "/api-reference/companies/upsert-user-trait"
     permanent: true
   - source: "/availability"
-    destination: "/architecture/availability"
+    destination: "/production_readiness/availability"
     permanent: true
   - source: /environments"
     destination: "/developer_resources/environments"

--- a/fern/docs/pages/production_readiness/availability.mdx
+++ b/fern/docs/pages/production_readiness/availability.mdx
@@ -1,7 +1,7 @@
 ---
 title: Availability
 
-slug: architecture/availability
+slug: production_readiness/availability
 ---
 
 

--- a/fern/docs/pages/production_readiness/observability.mdx
+++ b/fern/docs/pages/production_readiness/observability.mdx
@@ -1,7 +1,7 @@
 ---
 title: Observability & Support
 
-slug: architecture/observability
+slug: production_readiness/observability
 ---
 
 

--- a/fern/docs/pages/production_readiness/roles-and-permissions.mdx
+++ b/fern/docs/pages/production_readiness/roles-and-permissions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roles & Permissions
-slug: architecture/roles-and-permissions
+slug: production_readiness/roles-and-permissions
 ---
 
 Schematic uses role-based access control (RBAC) to govern what each of your team members can do. You manage your team and their access from **Settings → Team**.

--- a/fern/docs/pages/production_readiness/security.mdx
+++ b/fern/docs/pages/production_readiness/security.mdx
@@ -1,7 +1,7 @@
 ---
 title: Security
 
-slug: architecture/security
+slug: production_readiness/security
 ---
 
 


### PR DESCRIPTION
Four pages in `fern/docs/pages/production_readiness/` declared `slug: architecture/...` in frontmatter, so they served under `/architecture/`. None of them is architecture content. Three are security and procurement material, and one is admin UI documentation for Settings → Team. Someone looking for security posture will not guess `/architecture/`.

| Old | New |
|---|---|
| `/architecture/security` | `/production_readiness/security` |
| `/architecture/availability` | `/production_readiness/availability` |
| `/architecture/observability` | `/production_readiness/observability` |
| `/architecture/roles-and-permissions` | `/production_readiness/roles-and-permissions` |

Adds a redirect for each old URL, and repoints the two existing redirects that pointed into `/architecture/` so they resolve in one hop instead of chaining.

Note for whoever picks up the marketing link work: the marketing site links at `/architecture/availability` and `/architecture/observability`. Redirects ship here, so nothing breaks either way.

Closes DEV-307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)