### PR TITLE
chore(docs): remove malformed duplicate /environments redirect

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -628,9 +628,6 @@ redirects:
   - source: "/availability"
     destination: "/architecture/availability"
     permanent: true
-  - source: /environments"
-    destination: "/developer_resources/environments"
-    permanent: true
   - source: "/developer_resources/entity-key-management"
     destination: "/developer_resources/key_management"
     permanent: true


### PR DESCRIPTION
The `redirects:` block had this entry:

```yaml
  - source: /environments"
```

The value is unquoted with a stray trailing quote, so YAML parses the source as the literal string `/environments"`. No request path can contain that character, so the redirect never matched anything.

The same source is already declared correctly further down in the block with the same destination, so this deletes the broken duplicate rather than repairing it. `/environments` keeps redirecting exactly as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)