### PR TITLE
docs: keep the generated SDK pages byte-identical to their READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ generated/*
 **/.preview/**
 node_modules
 .claude/*
+
+__pycache__/
+*.pyc

--- a/fern/docs/pages/developer_resources/sdks/csharp.mdx
+++ b/fern/docs/pages/developer_resources/sdks/csharp.mdx
@@ -20,7 +20,7 @@ or using the NuGet Command Line Interface (CLI):
 nuget install SchematicHQ.Client
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
 
 3. Using this secret key, initialize a client in your application:
 
@@ -32,7 +32,7 @@ Schematic schematic = new Schematic("YOUR_API_KEY")
 
 ## Usage
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 

--- a/fern/docs/pages/developer_resources/sdks/go.mdx
+++ b/fern/docs/pages/developer_resources/sdks/go.mdx
@@ -12,7 +12,7 @@ slug: developer_resources/sdks/go
 go get github.com/schematichq/schematic-go
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with the Schematic Go library.
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with the Schematic Go library.
 
 3. Using this secret key, initialize a client in your Go application:
 
@@ -92,7 +92,7 @@ func main() {
 
 ## Usage examples
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 

--- a/fern/docs/pages/developer_resources/sdks/java.mdx
+++ b/fern/docs/pages/developer_resources/sdks/java.mdx
@@ -32,7 +32,7 @@ Using Maven in `pom.xml`:
 </dependency>
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
 
 3. Using this secret key, initialize a client in your application:
 
@@ -46,7 +46,7 @@ Schematic schematic = Schematic.builder()
 
 ## Usage
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 

--- a/fern/docs/pages/developer_resources/sdks/nodejs.mdx
+++ b/fern/docs/pages/developer_resources/sdks/nodejs.mdx
@@ -16,7 +16,7 @@ yarn add @schematichq/schematic-typescript-node
 pnpm add @schematichq/schematic-typescript-node
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with schematic-typescript-node.
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with schematic-typescript-node.
 
 3. Using this secret key, initialize a client in your application:
 
@@ -173,7 +173,7 @@ The `logLevel` option only affects the default console logger. When you supply y
 
 ## Usage examples
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 

--- a/fern/docs/pages/developer_resources/sdks/python.mdx
+++ b/fern/docs/pages/developer_resources/sdks/python.mdx
@@ -20,7 +20,7 @@ pip install schematichq
 poetry add schematichq
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
 
 3. Using this secret key, initialize a client in your application:
 
@@ -142,7 +142,7 @@ except schematic.core.ApiError as e: # Handle all errors
 
 ## Usage examples
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 

--- a/fern/docs/pages/developer_resources/sdks/ruby.mdx
+++ b/fern/docs/pages/developer_resources/sdks/ruby.mdx
@@ -24,7 +24,7 @@ Then run:
 bundle install
 ```
 
-2. [Issue an API key](/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with schematic-ruby.
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys). Be sure to capture the secret key when you issue the API key; you'll only see this key once, and this is what you'll use with schematic-ruby.
 
 3. Using this secret key, initialize a client in your application:
 
@@ -147,7 +147,7 @@ If no logger is provided, the client will use a default console logger at the `:
 
 ## Usage Examples
 
-A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).
+A number of these examples use `keys` to identify companies and users. Learn more about keys [here](https://docs.schematichq.com/developer_resources/key_management).
 
 ### Sending identify events
 


### PR DESCRIPTION
Follow-up to #399.

`go`, `java`, `nodejs`, `python`, `ruby`, and `csharp` are not hand-maintained. `scripts/sync_sdk_readmes.py` rewrites them from their SDK repo READMEs, and the weekly Sync SDK READMEs workflow opens a PR whenever they drift. #399 converted their `docs.schematichq.com` links to root-relative, which would have been reverted on the next run.

This restores the absolute form on those six pages. Absolute is correct there: the same text ships as the README on GitHub, npm, RubyGems, and pkg.go.dev, where a rooted path resolves against the wrong host.

The actual fixes, the corrected quickstart anchor and the Go `reference.md` link, are landing at the source instead:

| repo | PR |
| --- | --- |
| schematic-go | SchematicHQ/schematic-go#195 |
| schematic-java | SchematicHQ/schematic-java#89 |
| schematic-node | SchematicHQ/schematic-node#157 |
| schematic-python | SchematicHQ/schematic-python#94 |
| schematic-ruby | SchematicHQ/schematic-ruby#42 |
| schematic-csharp | SchematicHQ/schematic-csharp#172 |

Running the sync logic against those six branches reproduces these files byte for byte, so once they merge the sync is a no-op.

Also adds `__pycache__` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)