### PR TITLE
chore(docs): document awaiting client close for event durability

### DIFF
--- a/fern/docs/pages/developer_resources/sdks/cross-platform-features.mdx
+++ b/fern/docs/pages/developer_resources/sdks/cross-platform-features.mdx
@@ -28,7 +28,9 @@ The SDKs automatically handle network outages and connection drops by detecting 
 
 ## Event Buffering
 
-Our SDKs implement intelligent event buffering to batch multiple events together before sending them to the Schematic service. This reduces the number of network requests, and allows for event tracking to be asynchronous from the standpoint of your application. All SDKs implement automatic retries on failure, flush events when the application is closed, and handle network interruptions gracefully.
+Our SDKs implement intelligent event buffering to batch multiple events together before sending them to the Schematic service. This reduces the number of network requests, and allows for event tracking to be asynchronous from the standpoint of your application. All SDKs implement automatic retries on failure and handle network interruptions gracefully.
+
+Because buffered events are not yet on the server when `track()` returns, closing the client is what flushes them — and closing is a blocking operation. **Await (or otherwise wait on) the SDK's close method in your shutdown handler**; a fire-and-forget close followed by process exit drops whatever is still buffered. See the individual SDK pages for the graceful-shutdown pattern in your language.
 
 ## Local Caching
 

--- a/fern/docs/pages/developer_resources/sdks/go.mdx
+++ b/fern/docs/pages/developer_resources/sdks/go.mdx
@@ -90,6 +90,43 @@ func main() {
 }
 ```
 
+## Graceful shutdown
+
+Events recorded with `Track()` are buffered client-side and flushed on an interval, so they are not yet on the server when `Track()` returns. `client.Close()` flushes the buffer (with retries and exponential backoff) and blocks until that flush completes, so `defer client.Close()` in `main()` is enough to guarantee delivery on a normal exit. The wait is bounded, so a wedged network cannot hang your shutdown path indefinitely.
+
+Signals are not a normal exit, though — a process killed by SIGTERM never runs deferred functions. Trap the signal so `Close` actually gets called:
+
+```go
+func main() {
+  client := schematicclient.NewSchematicClient(option.WithAPIKey(os.Getenv("SCHEMATIC_API_KEY")))
+  defer client.Close()
+
+  sigs := make(chan os.Signal, 1)
+  signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+  // ... run your server ...
+
+  <-sigs
+  server.Shutdown(context.Background()) // stop accepting new work first
+  client.Close()                        // then flush any buffered events
+}
+```
+
+If a specific event needs to be durable before your code proceeds — rather than only at shutdown — call `Flush` to send the buffer without closing the client:
+
+```go
+client.Track(ctx, &schematicgo.EventBodyTrack{
+  Event:   "some-event-subtype",
+  Company: map[string]string{"company_id": "your-company-id"},
+})
+
+if err := client.Flush(ctx); err != nil {
+  // the event was not delivered; retry or record it for replay
+}
+```
+
+Events are deduplicated server-side on the idempotency key for 24 hours, so retrying a send that may or may not have landed is safe.
+
 ## Usage examples
 
 A number of these examples use `keys` to identify companies and users. Learn more about keys [here](/developer_resources/key_management).

--- a/fern/docs/pages/developer_resources/sdks/nodejs.mdx
+++ b/fern/docs/pages/developer_resources/sdks/nodejs.mdx
@@ -118,7 +118,7 @@ await client.events.createEvent({
 });
 ```
 
-Events are deduplicated server-side on the idempotency key for 24 hours, so retrying a send that may or may not have landed is safe. Unlike `close()`, which logs a failed flush and resolves anyway, this path surfaces the error to you.
+Events are deduplicated server-side on the idempotency key for 24 hours, so retrying a send that may or may not have landed is safe.
 
 ### Custom Logging
 

--- a/fern/docs/pages/developer_resources/sdks/nodejs.mdx
+++ b/fern/docs/pages/developer_resources/sdks/nodejs.mdx
@@ -28,7 +28,7 @@ const client = new SchematicClient({ apiKey });
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
 
 By default, the client will do some local caching for flag checks. If you would like to change this behavior, you can do so using an initialization option to specify the max size of the cache (in terms of number of records) and the max age of the cache (in milliseconds):
@@ -48,7 +48,7 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
 
 You can also disable local caching entirely with an initialization option; bear in mind that, in this case, every flag check will result in a network request:
@@ -66,7 +66,7 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
 
 You may want to specify default flag values for your application, which will be used if there is a service interruption or if the client is running in offline mode (see below). You can do this using an initialization option:
@@ -84,8 +84,41 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
+
+### Graceful shutdown
+
+Events recorded with `track()` are buffered client-side and flushed on an interval, so they are not yet on the server when `track()` returns. `client.close()` flushes the buffer — but it returns a promise, so you must **await** it. An unawaited `close()` followed by `process.exit()` drops whatever is still in the buffer.
+
+Close the client from your shutdown handler:
+
+```ts
+const shutdown = async () => {
+    await server.close(); // stop accepting new work first
+    await client.close(); // then flush any buffered events
+    process.exit(0);
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+```
+
+If a specific event needs to be durable before your code proceeds — rather than only at shutdown — send it directly through the events API and await the round trip. This bypasses the buffer entirely:
+
+```ts
+await client.events.createEvent({
+    eventType: "track",
+    body: {
+        company: { id: "your-company-id" },
+        event: "some-event-subtype",
+        quantity: 1,
+    },
+    idempotencyKey: "your-idempotency-key",
+});
+```
+
+Events are deduplicated server-side on the idempotency key for 24 hours, so retrying a send that may or may not have landed is safe. Unlike `close()`, which logs a failed flush and resolves anyway, this path surfaces the error to you.
 
 ### Custom Logging
 
@@ -125,7 +158,7 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
 
 Example using a popular logging library like Winston:
@@ -154,7 +187,7 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```
 
 If no logger is provided, the client uses a default console logger. By default it only emits `warn` and `error` messages; `debug` and `info` are suppressed to keep production output quiet. Use the `logLevel` option to raise or lower the verbosity of the default logger:
@@ -203,7 +236,7 @@ client.identify({
     },
 });
 
-client.close();
+await client.close();
 ```
 
 This call is non-blocking and there is no response to check.
@@ -229,7 +262,7 @@ client.track({
     },
 });
 
-client.close();
+await client.close();
 ```
 
 This call is non-blocking and there is no response to check.
@@ -315,7 +348,7 @@ client.companies
     })
     .catch(console.error);
 
-client.close();
+await client.close();
 ```
 
 You can define any number of company keys; these are used to address the company in the future, for example by updating the company's traits or checking a flag for the company.
@@ -353,7 +386,7 @@ client.companies
     })
     .catch(console.error);
 
-client.close();
+await client.close();
 ```
 
 You can define any number of user keys; these are used to address the user in the future, for example by updating the user's traits or checking a flag for the user.
@@ -389,7 +422,7 @@ client
     })
     .catch(console.error);
 
-client.close();
+await client.close();
 ```
 
 ### Checking flags with entitlement details
@@ -423,7 +456,7 @@ client
     })
     .catch(console.error);
 
-client.close();
+await client.close();
 ```
 
 ### Checking multiple flags
@@ -465,7 +498,7 @@ client
     })
     .catch(console.error);
 
-client.close();
+await client.close();
 ```
 
 ### Other API operations
@@ -733,7 +766,7 @@ const flagValue = await client.checkFlag(
     "some-flag-key",
 );
 
-client.close();
+await client.close();
 ```
 
 ### Configuration options
@@ -864,6 +897,12 @@ await client.trackWithReservation(result.reservation!, inference.tokensUsed);
 
 If the caller never settles a reservation, it expires after `defaultReservationTTL` and its credits are returned to the lease. If the work outlives the reservation's TTL, `trackWithReservation` still bills the usage — the track event carries a deterministic idempotency key, so duplicate or recovery emits never double-bill. However, the local lease balance is not re-debited on that late settle (the expired reservation's hold was already swept back to the lease), so it reads high until the lease rolls over. **Set `defaultReservationTTL` above the longest expected gap between `check()` and `trackWithReservation()`** to keep the local balance accurate.
 
+<Warning>
+`trackWithReservation()` settles the reservation locally and enqueues the track event on the buffer; the redemption is only billed once that event reaches Schematic. If the process exits before the buffer flushes, the redemption is lost and the lease refunds its unspent hold at release or expiry — so the work goes unbilled.
+
+Await `client.close()` in your shutdown handler (see [Graceful shutdown](#graceful-shutdown)) so in-flight redemptions are flushed on SIGTERM. The `Reservation` handle is a plain serializable object, and the redemption carries a deterministic idempotency key derived from the reservation id, so you can also persist the handle alongside your own work record and re-emit `trackWithReservation()` on restart — a replay collapses to a single billed redemption.
+</Warning>
+
 ### Pre-warming
 
 To avoid paying the lease-acquire round trip on a session's first check, pre-warm leases when the user is identified:
@@ -918,7 +957,7 @@ import { SchematicClient } from "@schematichq/schematic-typescript-node";
 
 const client = new SchematicClient({ offline: true });
 
-client.close();
+await client.close();
 ```
 
 Offline mode works well with flag defaults:
@@ -933,5 +972,5 @@ const client = new SchematicClient({
 
 // interactions with the client
 
-client.close();
+await client.close();
 ```


### PR DESCRIPTION
Reported by a customer in #schematic-syrto. Credit lease redemption goes out as a buffered `track` event; a SIGTERM during a normal deploy dropped it, the lease refunded its unspent hold at expiry, and work already paid for went unbilled. The mitigation is `await client.close()` in a shutdown handler — but nothing in our docs says so, and every Node example shows `close()` unawaited.

- **nodejs.mdx** — await `client.close()` in all 16 examples. New **Graceful shutdown** section with a SIGTERM handler and the direct `client.events.createEvent()` path for callers who need one specific event durable without shutting down. New warning in the credit lease section: a redemption is only billed once its track event reaches Schematic, and the `Reservation` handle is serializable with a deterministic idempotency key, so persisting it and re-emitting on restart is safe.
- **go.mdx** — equivalent **Graceful shutdown** section, covering the Go-specific trap that deferred functions never run on SIGTERM, plus `client.Flush(ctx)`.
- **cross-platform-features.mdx** — "flush events when the application is closed" implied this is automatic; now states the await requirement.

The go.mdx section describes behavior from SchematicHQ/schematic-go#196 (blocking `Close()`, new `Flush(ctx)`), so it should merge after that ships. The Node and cross-platform changes describe today's behavior and are independent.

## Verification

- `fern check` — 0 errors, 52 warnings; identical warning count on the `origin/main` base commit, so nothing regressed.
- Node claims verified against `SchematicHQ/schematic-node` (the live SDK) at `main`:
  - `close()` is genuinely awaitable and flushes: `src/wrapper.ts:767` → `eventBuffer.stop()` at :777 → `await this.flush()` (`src/events.ts`).
  - The direct path signature matches: `client.events.createEvent(request: CreateEventRequestBody)` in `src/api/resources/events/client/Client.ts:476`, whose own doc example is `await client.events.createEvent({ eventType: "flag_check" })`.
  - Note for whoever reviews: `SchematicHQ/schematic-typescript-node` is a stale 2024 repo (v1.0.23) with a different, incompatible surface (`client.Events`, `createEventRequestBody` wrapper). These docs target `schematic-node`, which is correct, but it is an easy trap.
- Not rendered in a browser; `fern generate --docs` needs credentials this environment doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)