### PR TITLE
DEV-284: add the marketing link contract and its redirect safety net

### DIFF
--- a/LINK_CONTRACT.md
+++ b/LINK_CONTRACT.md
@@ -1,0 +1,104 @@
+# Marketing to docs link contract
+
+The canonical list of docs URLs the marketing site is safe to link to. Every URL here is covered by a `redirects:` entry in `fern/docs.yml`, so docs can be restructured without breaking the site.
+
+If you need to link somewhere not on this list, open a docs ticket first so a redirect ships alongside it. That is the whole point of the contract: docs owns its own structure, and marketing gets URLs that do not move.
+
+## Before you link, read this
+
+**Fern serves HTTP 200 for unknown slugs.** A dead docs link returns 200 with a generic page titled `Documentation`. A status-code check will pass on a 404. Verify by title instead:
+
+```sh
+curl -sL https://docs.schematichq.com<slug> | grep -oiE "<title>[^<]*</title>"
+```
+
+If the title comes back as bare `Documentation`, the link is dead.
+
+**Page slugs do not match file paths.** Several pages were re-slugged during the docs IA work, so do not infer a URL from a file path or from an older link you found somewhere. Use this table.
+
+## Canonical URLs
+
+All relative to `https://docs.schematichq.com`.
+
+| What you are linking to | URL |
+| --- | --- |
+| Docs home | `/overview` |
+| What is Schematic | `/what-is-schematic` |
+| Concepts and vocabulary | `/concepts` |
+| Quickstart | `/quickstart/overview` |
+| Developer landing page | `/developers` |
+| For product teams | `/product-teams` |
+| Use cases index | `/use-cases/overview` |
+
+### Components
+
+| What you are linking to | URL |
+| --- | --- |
+| Components overview | `/components/overview` |
+| Customer portal and checkout | `/components/customer-portal` |
+| Pricing table | `/components/pricing-table` |
+| Element library | `/components/element-library` |
+| Adding components to your app | `/components/set-up` |
+
+### Billing and credits
+
+| What you are linking to | URL |
+| --- | --- |
+| Billing overview | `/billing/overview` |
+| Credit burndown, including auto top-up | `/billing/credit-burndown` |
+| Usage-based billing | `/billing/usage-based-billing` |
+| Seat-based billing | `/billing/seat-based-billing` |
+| Credit billing use case | `/use-cases/credit-billing` |
+| Real-time ledger and holds | `/use-cases/credit-ledger` |
+| Usage-based pricing use case | `/use-cases/usage-based-pricing` |
+| Custom plans | `/catalog/custom-plans` |
+
+### Trust and enterprise
+
+| What you are linking to | URL |
+| --- | --- |
+| Security, SOC 2, encryption, SSO | `/production_readiness/security` |
+| Availability, HA strategies, Replicator | `/production_readiness/availability` |
+| Observability and support | `/production_readiness/observability` |
+| Roles and permissions | `/production_readiness/roles-and-permissions` |
+
+Note that these live under `/production_readiness/`, not `/architecture/`. The `/architecture/*` URLs still work as redirects, but link to the canonical form above.
+
+### Integrations and AI tooling
+
+| What you are linking to | URL |
+| --- | --- |
+| Stripe integration | `/integrations/stripe` |
+| Integrations index | `/integrations/overview` |
+| Webhooks | `/integrations/webhooks` |
+| AI tooling for developers, including MCP | `/for-developers` |
+| The MCP section specifically | `/for-developers#model-context-protocol-mcp` |
+
+## Short aliases
+
+These shorter URLs all redirect to the canonical pages above and are safe to use in body copy where a shorter link reads better:
+
+`/security` · `/availability` · `/observability` · `/roles-and-permissions` · `/quickstart` · `/components` · `/billing` · `/credits` · `/credit-burndown` · `/customer-portal` · `/pricing-table` · `/webhooks` · `/integrations` · `/sdks` · `/use-cases` · `/playbooks` · `/trials` · `/add-ons` · `/mcp` · `/flags` · `/features`
+
+`/concepts` and `/developers` are canonical page slugs rather than aliases, so they appear in the tables above.
+
+## Known corrections
+
+Four links on the v2 build resolve but land on a page that does not answer the label. These are tracked in DEV-284 and DEV-296 and need fixing on the marketing side.
+
+| Link on /v2 | Currently points at | Should point at |
+| --- | --- | --- |
+| Enterprise → Availability → Learn more | `schematic.statuspage.io` | `/production_readiness/availability` |
+| Enterprise → Observability → Learn more | `/security` | `/production_readiness/observability` |
+| View all components → | docs root | `/components/overview` |
+| Developers → Read the docs | docs root | `/quickstart/overview` |
+
+Both `/developers` CTAs (the "Schematic for developers →" link and the footer "Developers" link) should point at `/developers` on the docs site, which is the developer landing page that replaced the marketing `/developers` page.
+
+## Docs to marketing
+
+Docs links back out to the marketing site in three places in `fern/docs.yml`. If any of these URLs move during the site transition, update them here:
+
+- `tabs:` — the Blog tab points at `https://schematichq.com/blog`, the Roadmap tab at `https://roadmap.schematichq.com/`
+- `navbar-links:` — a support mailto and the app dashboard
+- `footer-links:` — GitHub, LinkedIn, and `https://schematichq.com/`

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -122,6 +122,12 @@ navigation:
                 path: ./docs/pages/use-cases/automation.mdx
               - link: Protect your margins
                 href: /use-cases/margin-protection
+      - section: AI tooling
+        contents:
+          - page: For Developers
+            path: ./docs/pages/ai_tooling/for-developers.mdx
+          # - page: For GTM Teams
+          #   path: ./docs/pages/ai_tooling/for-gtm-teams.mdx
       - section: Model your pricing
         contents:
           - page: Overview
@@ -377,12 +383,6 @@ navigation:
             path: ./docs/pages/troubleshooting/overview.mdx
           - page: Commonly Seen Stripe Issues
             path: ./docs/pages/integrations/stripe-faq.mdx
-      - section: AI tooling
-        contents:
-          - page: For Developers
-            path: ./docs/pages/ai_tooling/for-developers.mdx
-          # - page: For GTM Teams
-          #   path: ./docs/pages/ai_tooling/for-gtm-teams.mdx
   - tab: api
     layout:
       - page: Resources

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -711,6 +711,51 @@ redirects:
   - source: "/documentation/build/sd-ks/javascript-client-side"
     destination: "/developer_resources/sdks/javascript"
     permanent: true
+  - source: "/observability"
+    destination: "/production_readiness/observability"
+    permanent: true
+  - source: "/roles-and-permissions"
+    destination: "/production_readiness/roles-and-permissions"
+    permanent: true
+  - source: "/billing"
+    destination: "/billing/overview"
+    permanent: true
+  - source: "/credits"
+    destination: "/billing/credit-burndown"
+    permanent: true
+  - source: "/credit-burndown"
+    destination: "/billing/credit-burndown"
+    permanent: true
+  - source: "/customer-portal"
+    destination: "/components/customer-portal"
+    permanent: true
+  - source: "/pricing-table"
+    destination: "/components/pricing-table"
+    permanent: true
+  - source: "/webhooks"
+    destination: "/integrations/webhooks"
+    permanent: true
+  - source: "/integrations"
+    destination: "/integrations/overview"
+    permanent: true
+  - source: "/sdks"
+    destination: "/developer_resources/sdks/overview"
+    permanent: true
+  - source: "/use-cases"
+    destination: "/use-cases/overview"
+    permanent: true
+  - source: "/playbooks"
+    destination: "/playbooks/overview"
+    permanent: true
+  - source: "/trials"
+    destination: "/catalog/trials"
+    permanent: true
+  - source: "/add-ons"
+    destination: "/catalog/add-ons"
+    permanent: true
+  - source: "/mcp"
+    destination: "/for-developers#model-context-protocol-mcp"
+    permanent: true
     # old api references that are wrong for some reason
   - source: "/api-reference/companies/list-company-plans"
     destination: "/api-reference/companies/list-company-memberships"


### PR DESCRIPTION
Closes the docs half of [DEV-284](https://linear.app/schematic/issue/DEV-284/marketing-to-docs-link-contract-both-directions). The marketing half is a handoff, since the v2 site is not in `schematic-ms` yet.

## What this fixes

The marketing site hardcodes docs URLs, so any docs restructure can silently break it. Fern serves HTTP 200 with a generic page titled `Documentation` for unknown slugs, which means a dead link passes a status-code check. The only reliable test is comparing the resolved page title against what the link promised.

Title-checking candidate slugs against the live site turned up a real gap. `/security` and `/availability` both have short-slug redirects; `/observability` was missed and is dead today. So are `/credits`, `/billing`, `/webhooks`, `/customer-portal`, `/pricing-table`, `/sdks`, `/integrations`, `/use-cases`, `/playbooks`, `/trials`, `/add-ons`, and `/mcp`.

## Changes

- **`fern/docs.yml`**: 15 short-slug redirects covering the marketing-facing destinations, following the pattern already established by `/security`, `/availability`, `/quickstart`, and `/components`.
- **`LINK_CONTRACT.md`**: the canonical list marketing works from, with the title-check command, the four known mis-aimed links, and the docs-to-marketing links that need watching during the transition.

## One correction to the ticket

DEV-284 says to point marketing at `/architecture/availability` and `/architecture/observability`. Those pages were re-slugged to `/production_readiness/*`, the opposite direction from what the ticket assumed. The `/architecture/*` URLs still resolve via existing redirects, so nothing is broken, but the contract points at the canonical form.

## Verification

- All 15 redirect destinations confirmed to resolve by title against `docs.schematichq.com`.
- All existing redirect destinations in the block also spot-checked and healthy.
- `fern check` passes with 0 errors. The 52 warnings are pre-existing OpenAPI endpoint path conflicts, untouched by this PR.

## Handoff for the marketing side

| Link on /v2 | Currently points at | Should point at |
| --- | --- | --- |
| Enterprise → Availability → Learn more | `schematic.statuspage.io` | `/production_readiness/availability` |
| Enterprise → Observability → Learn more | `/security` | `/production_readiness/observability` |
| View all components → | docs root | `/components/overview` |
| Developers → Read the docs | docs root | `/quickstart/overview` |

Both `/developers` CTAs should point at `/developers` on the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)