### PR TITLE
DEV-291: document who controls auto top-up, and add a spend controls page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -188,6 +188,8 @@ navigation:
                 href: /use-cases/credit-billing
               - link: Real-time ledger & holds
                 href: /use-cases/credit-ledger
+          - page: Spend & Usage Controls
+            path: ./docs/pages/billing/spend-controls.mdx
           - page: Seat Based Billing Models
             path: ./docs/pages/billing/seat-based-billing.mdx
           - page: Billing Entities

--- a/fern/docs/pages/billing/credit-burndown.mdx
+++ b/fern/docs/pages/billing/credit-burndown.mdx
@@ -212,11 +212,39 @@ In addition to manually purchasing credits, Schematic supports auto top-up for c
 7. Finally, we provide a confirmation warning with the final cost, threshold, and expiration policy.
 8. Click "Create plan grant" to save your changes.
 
+### Who controls auto top-up
+
+Each credit grant sets whether auto top-up is available and who operates it:
+
+| Availability | Behavior |
+| --- | --- |
+| `off` | Auto top-up is unavailable on this grant |
+| `automatic` | You configure it and it runs. The customer does not turn it on or off. |
+| `user_controlled` | The customer decides whether auto top-up is on, from the customer portal |
+
+Choose `user_controlled` when you want customers managing their own refills, which is the usual arrangement for self-serve plans, and `automatic` when continuity matters more than customer control, such as an enterprise account that should never be interrupted mid-workload.
+
+Separately, `can_buy_bundles` controls whether customers can purchase one-time [credit bundles](#5-configure-credit-bundles-that-customers-can-purchase-to-top-up-their-balance) themselves. It is independent of auto top-up availability, so you can let a customer buy credits on demand without also letting them set up an automatic refill, or the reverse.
+
+### Setting the threshold
+
+The example above uses a percentage of the remaining balance. You can set the threshold as an absolute number of credits instead, which is usually the clearer choice when a plan's grant size varies between companies, since a fixed percentage of a larger grant means a larger buffer.
+
+The two threshold forms are alternatives. Set the one that matches how you want the trigger to scale.
+
+### Overriding auto top-up for a single company
+
+Auto top-up is configured on the plan, so every company on that plan inherits the same settings. You can override the amount, the threshold, and whether it is enabled for an individual company without creating a separate plan. This is the usual way to handle an enterprise account that needs a larger refill than the plan's default, or a company that has asked you to turn automatic purchasing off.
+
 ### Triggering an Auto Top-Up
 
 Auto top-ups are triggered when processing an event that draws from a credit balance and the customer's balance is at or below the remaining balance threshold. Schematic ensures that if multiple events trigger in a short period of time, only one auto top-up will be purchased. 
 
 In the event that an auto top-up purchase fails, Schematic will try to purchase an auto top-up grant the next time the balance is drawn from.
+
+Three webhook events report the outcome of each attempt: `auto.topup.success`, `auto.topup.hard.failure`, and `auto.topup.retry.exceeded`. A hard failure carries the Stripe error code when the failure originated there, which is what lets you tell a declined card apart from a missing payment method. See [Entitlement & Credit Trigger Webhooks](/integrations/webhooks/entitlement-triggers#auto-topup-events) for the full payloads.
+
+Because a failing top-up means a customer is about to be cut off, wiring `auto.topup.hard.failure` to an internal alert and a customer-facing email is worth doing before you turn auto top-up on. See [Spend and usage controls](/billing/spend-controls) for how auto top-up fits with the other limits available to you.
 
 ## Accessing Credit Information via API
 

--- a/fern/docs/pages/billing/spend-controls.mdx
+++ b/fern/docs/pages/billing/spend-controls.mdx
@@ -1,0 +1,61 @@
+---
+title: Spend & Usage Controls
+description: The limits, thresholds, and top-up settings that keep usage inside a budget, and which of them your customers operate themselves.
+
+slug: billing/spend-controls
+---
+
+Usage-based pricing puts two parties at risk. You need protection from a customer whose usage outruns what they are paying for, and the customer needs protection from a bill they did not see coming. Both are solved with the same set of controls, pointed in different directions.
+
+This page is a map of what is available and where each control is configured. The detailed setup lives on the pages linked from each section.
+
+## The controls at a glance
+
+| Control | Applies to | Who sets it | Where |
+| --- | --- | --- | --- |
+| Hard limit | Metered features | You | [Usage-based billing](/billing/usage-based-billing) |
+| Soft limit | Overage pricing | You, visible to the customer | [Usage-based billing](/billing/usage-based-billing#fixed-fee-with-overage) |
+| Tier limit | Tiered pricing | Derived from your tiers | [Volume pricing](/billing/usage-based-billing#volume-pricing) |
+| Credit balance limit | Credit types | You | [Credit burndown](/billing/credit-burndown) |
+| Auto top-up | Credit grants | You, or the customer if you allow it | [Credit burndown](/billing/credit-burndown#auto-top-up) |
+| Bundle purchasing | Credit grants | You decide whether customers can | [Credit burndown](/billing/credit-burndown#who-controls-auto-top-up) |
+| Overrides | A single company | You | [Overrides](/feature-management/overrides) |
+
+## Limits on metered features
+
+Three limit types apply to features metered against usage, and they behave differently at the boundary.
+
+A **hard limit** is the point at which access is restricted. For usage included with a plan, that is the included amount. For [pay as you go](/billing/usage-based-billing#pay-as-you-go) and [overage pricing](/billing/usage-based-billing#fixed-fee-with-overage), where usage is not otherwise bounded, it is an upper bound you configure to prevent abuse or runaway spend. It is normally hidden from the customer.
+
+A **soft limit** does not restrict anything. Under overage pricing it marks the point where billed usage begins, and it is shown to the customer in Schematic components so they know when they cross from included usage into paid usage.
+
+A **tier limit** fires as a company crosses into each successive pricing tier under [tiered pricing](/billing/usage-based-billing#volume-pricing), which lets you tell them the rate is changing before the invoice does.
+
+Each of these has a `reached` event and a `warning` event that fires on approach, so you can act before the boundary rather than after. See [Entitlement & Credit Trigger Webhooks](/integrations/webhooks/entitlement-triggers) for the full event list and payloads.
+
+## Controls on a credit balance
+
+For [credit burndown](/billing/credit-burndown) plans, the balance itself is the limit. A company can only spend what it holds, so the controls are about what happens as the balance runs down.
+
+**Credit limit triggers** fire `credit.limit.warning` as a balance approaches its configured limit and `credit.limit.reached` when it gets there. These are configured per credit type.
+
+**Auto top-up** refills the balance automatically when it drops below a threshold, so a customer is not cut off mid-workload. Whether the customer or you operate it is a per-grant setting, and it can be overridden for an individual company. See [Who controls auto top-up](/billing/credit-burndown#who-controls-auto-top-up).
+
+**Bundle purchasing** lets a customer buy more credits on demand. It is controlled independently of auto top-up, so you can offer one without the other.
+
+Which credits get spent first, and what happens to an unused balance at the end of a period, are governed by the credit type's burn strategy and rollover settings. See [Credit burndown](/billing/credit-burndown).
+
+## Exceptions for a single company
+
+Everything above is configured on a plan or a credit type, so every company on that plan inherits it. When one company needs different treatment, an [override](/feature-management/overrides) changes the entitlement for that company alone, and auto top-up settings can be overridden per company in the same spirit.
+
+Overrides can be time-limited, which is the right shape for a temporary limit increase you do not want to become permanent. See [Manage exceptions with overrides](/use-cases/overrides).
+
+## Making the controls visible to customers
+
+A limit the customer cannot see is a support ticket waiting to happen. Two surfaces close that gap:
+
+- **Components** show current usage against entitlements in the customer portal, including credit balances and the soft limit at which billed usage begins. See the [Element Library](/components/element-library).
+- **Webhooks** let you drive your own in-app banners and emails off the same warning events your internal alerting uses. See [Entitlement & Credit Trigger Webhooks](/integrations/webhooks/entitlement-triggers).
+
+Wiring the warning events, not just the reached events, is what turns a hard stop into something the customer saw coming.


### PR DESCRIPTION
Closes [DEV-291](https://linear.app/schematic/issue/DEV-291/document-auto-top-up-and-spend-controls-end-to-end).

DEV-143 (Auto Topup Docs) is already merged and archived, so this extends from it rather than duplicating it.

## The gap this closes

The v2 site shows auto top-up as a customer-operated surface ("Customers set auto top-up and spend policies themselves"). Docs described it only as something the vendor configures on a plan. The API has carried the answer the whole time.

`auto_topup_availability` on each credit grant is `off`, `automatic`, or `user_controlled`. That is the direct answer to who operates the dial. `can_buy_bundles` gates one-time purchases independently, so a customer can be allowed to buy credits on demand without being allowed to set up an automatic refill. Neither was documented.

## Changes

**`billing/credit-burndown.mdx`** gains three subsections under Auto Top-Up:

- **Who controls auto top-up**: the availability model and when to pick each, plus how bundle purchasing is gated separately
- **Setting the threshold**: the absolute-credit form, which is an alternative to the percentage the walkthrough uses and usually clearer when grant sizes vary between companies
- **Overriding auto top-up for a single company**: amount, threshold, and enabled can differ per company without a separate plan

It also now links the three outcome webhooks (`auto.topup.success`, `auto.topup.hard.failure`, `auto.topup.retry.exceeded`). Those were already fully documented on the webhooks page but never referenced from the page where you set auto top-up up.

**`billing/spend-controls.mdx`** is new. "Spend & usage controls" is a named chip on the site with no docs page by that name. It is a map rather than a second copy of the detail: what each control is, who sets it, and which page configures it. Covers hard, soft, and tier limits, credit limit triggers, auto top-up, bundle purchasing, and overrides, plus a short section on making limits visible to customers.

**`fern/docs.yml`** adds the new page under "Bill for usage".

## Two deliberate omissions

**ACH is not mentioned.** `PaymentMethodResponseData` carries `bank_name` and `account_last4`, which is suggestive, but `payment_method_type` is an unconstrained string so nothing in the spec confirms ACH. Left out rather than asserted; asked on the ticket.

**"Spend policies" is not presented as a feature.** There is no such object in the API. The new page describes the controls that exist without inventing a policy engine to hold them.

## Source of truth

- `BillingCreditAutoTopupAvailability` (`schematic.yaml:569`)
- `BillingPlanCreditGrantResponseData` for `auto_topup_threshold_credits` / `_percent` and `can_buy_bundles`. Note `auto_topup_enabled` and `auto_topup_self_service` are marked deprecated in favor of `auto_topup_availability`, which is why the docs describe availability rather than the two booleans.
- `UpdateAutoTopupOverrideRequestBody` (`:14272`) for the per-company override

## Merge order

Touches the same file as #405 (DEV-285), in a different region, so they should merge cleanly either way. I avoided deep-linking into #405's new headings so nothing breaks if this lands first.

`fern check` passes with 0 errors. The 52 warnings are pre-existing OpenAPI path conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)