### PR TITLE
DEV-293: give Schematic's billable units a canonical definition in docs

### DIFF
--- a/fern/docs/pages/feature-management/flags.mdx
+++ b/fern/docs/pages/feature-management/flags.mdx
@@ -11,6 +11,8 @@ A significant difference between Schematic and other tools that offer flags is t
 
 For example, if a company is a part of a beta cohort, you can asynchronously update their profile in Schematic and that context will be used when the flag is evaluated. The full example is [here](/playbooks/rollout), and demonstrates how to check flags in your codebase.
 
+A **flag evaluation** is a single check of a flag for a given context. Evaluations do not have to be network calls: with [DataStream or the Replicator](/production_readiness/availability), flags are evaluated locally against a synced copy of the rules. See [Flag evaluation](/concepts#flag-evaluation) for the canonical definition.
+
 <iframe
   width="560"
   height="400"

--- a/fern/docs/pages/get_started/concepts.mdx
+++ b/fern/docs/pages/get_started/concepts.mdx
@@ -115,6 +115,59 @@ Every grant and every draw is written to the **credit ledger**, which is transac
 
 Components stay in sync with Schematic automatically, reflecting each company's current entitlements and subscription in real time. Read more in the [Components overview](/components/overview).
 
+## Billable units
+
+The concepts above describe how Schematic models your product. A few of them are also the units Schematic's own pricing is measured in, and those are defined here so there is one canonical answer to what each one counts.
+
+This page defines the units. The [pricing page](https://schematichq.com/pricing) has the numbers and what each plan includes.
+
+### Monetized subscription
+
+A **monetized subscription** is a company with an active subscription and a payment method, that has been billed or will be billed depending on usage or trial expiration. It is the primary unit Schematic's pricing is measured in.
+
+A company counts as a monetized subscription when it is:
+
+- On a plan with a recurring price
+- On a plan that charges per unit of usage
+- On a plan that includes some usage and charges for usage beyond it
+- In a trial that requires a payment method, since it will be billed at the end of the trial unless it cancels
+
+A company does not count when it is:
+
+- Without an active subscription managed by Schematic
+- On a free plan
+- In a trial that does not require a payment method
+
+The distinction is whether money is expected to change hands, not whether it already has. A trial that captured a payment method counts from the start of the trial.
+
+### Event volume
+
+An **event** is a single `identify` or `track` call your application sends to Schematic, and event volume is the count of them per month.
+
+Both types count. `identify` calls that create or update a company or user profile are events, as are `track` calls that record usage. The [Events](#events) section above covers the distinction between them.
+
+### Flag evaluation
+
+A **flag evaluation** occurs when you check a flag for a given context to determine if a user or company should be entitled to a resource in your application.
+
+Flag evaluations are unlimited on every plan, so this definition is for understanding rather than for predicting a bill. It is worth knowing that an evaluation is not the same thing as an API call: with [DataStream or the Replicator](/production_readiness/availability), flags are evaluated locally in your process against a synced copy of the rules, so a high-volume application can perform far more evaluations than it makes network requests.
+
+### Override
+
+An **override** is a per-company exception to what a plan grants for a specific feature. The count is of overrides currently in place, not of times an override was applied.
+
+Time-limited overrides expire on their own and stop counting once they do, which makes them the right shape for a temporary exception. See [Overrides](/feature-management/overrides).
+
+### Webhook
+
+A **webhook** is a configured endpoint Schematic delivers events to. The count is of endpoints you have configured, not of deliveries made to them, so one endpoint receiving many event types counts once. See [Webhooks](/integrations/webhooks).
+
+### Seats
+
+Seats are not a billable unit. Schematic does not charge per seat, and the number of people from your team who use Schematic does not affect what you pay.
+
+Note that this is separate from seat-based billing in your own product, where a seat may well be a unit you charge your customers for. See [Seat Based Billing Models](/billing/seat-based-billing).
+
 ## How Schematic evaluates access
 
 ### User and company profiles


### PR DESCRIPTION
Closes the docs half of [DEV-293](https://linear.app/schematic/issue/DEV-293/move-pricing-page-definitions-into-docs). The pricing-page FAQ edit is a handoff, since the v2 site is not in `schematic-ms` yet.

## What this does

Adds a **Billable units** section to `get_started/concepts.mdx`, defining monetized subscription, event volume, flag evaluation, override, webhook, and seats. It states the boundary the ticket asks for explicitly: docs define what the units mean, the pricing page owns the numbers and packaging.

`feature-management/flags.mdx` gets a short definition of flag evaluation pointing at the canonical entry, since that is where a reader looking for it will land.

## Two things that came out of writing it

**Flag evaluations are unlimited on every tier.** That resolves the open question in the plan about what counts as a billable evaluation given local evaluation via Replicator. It does not affect a bill, so the definition is for understanding. The section still notes that an evaluation is not the same as an API call, because a reader comparing Schematic to a per-evaluation-priced tool will assume otherwise.

**Override and webhook limits count configured objects, not occurrences.** One webhook endpoint receiving many event types counts once, and a time-limited override stops counting when it expires. The pricing table does not make either explicit, and both change how a reader reads the numbers.

## Handoff for the pricing page

These FAQ entries should link to docs rather than restate the definition, so the two cannot drift:

| Pricing page FAQ | Should link to |
| --- | --- |
| What is a flag evaluation? | `/concepts#flag-evaluation` |
| What counts as a "monetized subscription"? | `/concepts#monetized-subscription` |
| What DOES NOT count as a "monetized subscription"? | `/concepts#monetized-subscription` |
| Do you charge per seat? | `/concepts#seats` |

The comparison table rows for Events/month, Overrides, and Webhooks can link to `/concepts#event-volume`, `/concepts#override`, and `/concepts#webhook`.

## One discrepancy to check, not fixed here

The pricing page appears to contradict itself on the Free tier limit. The comparison table says **Up to 10** monetized subscriptions, while the FAQ asks "What happens when I cross **25** monetized subscriptions in the Free tier?" I did not put either number in docs, since docs deliberately do not carry the numbers, but one of the two is wrong on the site. Flagging for SCHX-635.

## Review note

The monetized subscription definition and the counts/does-not-count lists are lifted from the pricing page wording, lightly edited for docs voice. If the pricing page wording is itself out of date, this inherits that.

`fern check` passes with 0 errors. Verified no duplicate heading anchors were introduced (the billable-unit heading is "Event volume" rather than "Events" for exactly that reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)