### PR TITLE
DEV-294: write the GTM AI tooling page and put it in the nav

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -381,8 +381,8 @@ navigation:
         contents:
           - page: For Developers
             path: ./docs/pages/ai_tooling/for-developers.mdx
-          # - page: For GTM Teams
-          #   path: ./docs/pages/ai_tooling/for-gtm-teams.mdx
+          - page: For GTM Teams
+            path: ./docs/pages/ai_tooling/for-gtm-teams.mdx
   - tab: api
     layout:
       - page: Resources

--- a/fern/docs/pages/ai_tooling/for-developers.mdx
+++ b/fern/docs/pages/ai_tooling/for-developers.mdx
@@ -1,10 +1,12 @@
 ---
 title: AI Tooling
-description: Connect AI coding assistants to Schematic through the AI skills repos, the hosted MCP server, and the Claude plugin.
+description: Connect AI coding assistants to Schematic through the AI skills repos and the hosted MCP server.
 slug: for-developers
 ---
 
 Learn how to use Schematic with AI development tools and assistants to accelerate your integration and development workflow.
+
+<Info>Working in customer success, RevOps, or sales rather than engineering? See [For GTM Teams](/for-gtm-teams) for renewal prep, churn and expansion signals, and contract validation workflows.</Info>
 
 ## Overview
 
@@ -90,19 +92,6 @@ Read-only API keys can use only the read tools.
 - "Show me feature usage for the 'api_calls' feature across all companies"
 - "Create a company override to enable 'beta_features' for company comp_123"
 
-{/* 
-## Claude Plugin
-
-Schematic offers a Claude plugin that allows you to interact with Schematic directly from Claude. This plugin enables you to:
-
-- Query Schematic data through natural language
-- Generate integration code with full context of your Schematic setup
-- Get recommendations for plan configurations and feature entitlements
-
-### Installation
-
-Installation directions for the Claude plugin are coming soon. Once available, you'll be able to install the plugin directly from Claude's plugin directory.
-
 ## Best Practices
 
 ### Using AI Skills
@@ -117,7 +106,7 @@ When using Schematic AI Skills with your coding assistant:
 
 When working with the MCP integration:
 
-- **Secure your credentials** - Store API keys securely and never commit them to version control
-- **Use appropriate permissions** - Grant only the permissions needed for your use case
+- **Prefer OAuth over API keys** - An OAuth connection runs as you and respects your team member permissions, and permission changes take effect immediately
+- **Secure your credentials** - When you do use an API key, store it securely and never commit it to version control
+- **Use appropriate permissions** - Connect read-only unless you specifically need write access, and pick the environment deliberately
 - **Validate responses** - Verify that MCP queries return accurate data before using it in production
-*/}

--- a/fern/docs/pages/ai_tooling/for-gtm-teams.mdx
+++ b/fern/docs/pages/ai_tooling/for-gtm-teams.mdx
@@ -1,7 +1,74 @@
 ---
 title: For GTM Teams
+description: Use the Schematic MCP server from Claude to prep renewals, surface churn and expansion signals, and check what was sold against what was provisioned.
+
 slug: for-gtm-teams
 ---
 
+Customer success, RevOps, and sales teams all need the same thing from Schematic: an accurate picture of what a customer is entitled to and what they are actually using. That data lives in Schematic, but getting it out has usually meant either learning the dashboard or asking engineering.
 
+The [MCP server](/for-developers#model-context-protocol-mcp) removes both steps. Connect an MCP-compatible assistant such as Claude, and you can ask for what you need in plain language.
 
+This page covers the workflows GTM teams run most. For setting up the connection, and for the developer-facing tooling, see [AI Tooling](/for-developers).
+
+## Before you start
+
+You need an MCP-compatible AI assistant and a Schematic account. Sign in with OAuth rather than an API key: the connection then runs as you, respecting your team member permissions, and a change to your permissions takes effect immediately.
+
+When you connect you choose an environment and whether the connection is read-only or read and write. **Read-only is the right default for most GTM work.** Everything on this page except adjusting an entitlement works read-only, and it removes the possibility of a misread question changing a customer's account.
+
+Setup instructions are in [Connect with OAuth](/for-developers#connect-with-oauth).
+
+## Prepping a renewal
+
+The problem this solves is a CSM walking into a renewal without knowing how the account has actually been using the product. Assembling that by hand means the plan, the entitlements attached to it, and usage against each metered feature, which is a lot of clicking for a call that happens every quarter.
+
+Ask for it instead:
+
+- "What plan is Acme Corp on, and what entitlements does that plan include?"
+- "Show me Acme Corp's usage against each metered feature for the last 90 days."
+- "Which of Acme Corp's entitlements are they close to using up?"
+- "Has Acme Corp had any overrides applied, and are any of them expiring?"
+
+The last one matters more than it looks. An override granted during onboarding and never revisited is a common source of renewal surprises, because the customer has been using something their plan does not actually include.
+
+## Spotting churn and expansion signals
+
+The same data answers the opposite question, at portfolio scale rather than per account. Low usage against an entitlement is a churn signal. Usage pressing against a limit is an expansion signal.
+
+- "Which companies on the Pro plan have used less than 20% of their included usage this month?"
+- "Which companies are near the limit on any metered feature?"
+- "How many companies are on each plan right now?"
+- "Show me companies whose credit balance is running low."
+
+Run the first one on a schedule and it becomes a weekly churn sweep. Run the second and it becomes an upsell queue. Neither needs a dashboard or a report to be built first.
+
+## Checking what was sold against what was provisioned
+
+Custom deals are where entitlements drift from the contract, because the plan is configured by hand after the deal closes. Nobody usually checks the two against each other until a customer complains.
+
+- "What entitlements does the custom plan attached to Acme Corp include?"
+- "Compare the entitlements on Acme Corp's plan to these order form terms: [paste the terms]."
+- "List every company on a custom plan and what each one is entitled to."
+
+Running this over recently closed deals catches the mismatch while it is still cheap to fix. See [Close custom deals](/use-cases/custom-deals) for how custom plans are set up in the first place.
+
+## Adjusting an entitlement
+
+This one needs a read and write connection, and it is worth being deliberate about who has one.
+
+- "Set an override on Acme Corp for the api_calls feature at 50,000 for the next 30 days."
+- "List the overrides currently in place for Acme Corp."
+- "Remove the override on Acme Corp for beta_features."
+
+Time-limited overrides are the safer instrument for anything granted as a concession, since they expire on their own instead of quietly becoming permanent. See [Manage exceptions with overrides](/use-cases/overrides).
+
+A write connection can never do more than you can do in the Schematic app. If your account cannot change a plan, neither can an assistant connected as you.
+
+## Where this fits
+
+The MCP server is for ad-hoc questions and human-in-the-loop workflows. For automation that needs to run reliably without someone asking, use [webhooks](/integrations/webhooks) instead, which push events to Slack, your CRM, or any endpoint as they happen. [Automate with webhooks and AI](/use-cases/automation) covers how the two fit together.
+
+- [Spot churn and expansion with usage signals](/use-cases/usage-signals)
+- [Stay ahead of renewals and expirations](/use-cases/renewals)
+- [Expand accounts with upsells and add-ons](/use-cases/expand-accounts)


### PR DESCRIPTION
Closes [DEV-294](https://linear.app/schematic/issue/DEV-294/write-the-ai-and-agent-tooling-story-including-for-gtm-teams).

## The gap

`ai_tooling/for-gtm-teams.mdx` was 7 lines of frontmatter and two blank lines, and it was commented out of `navigation:`. It did not exist as far as readers or agents were concerned.

The v2 homepage ends its five-step sales-led sequence on an MCP scene where an agent pulls usage, limits, and the expansion case to prep a renewal, and treats that as a differentiator. There was nowhere for that reader to land.

## What the page covers

Four workflows, each with example prompts:

- **Prepping a renewal**: plan, attached entitlements, 90 days of usage per metered feature, and any overrides that are expiring
- **Spotting churn and expansion signals**: low usage against an entitlement as a churn signal, usage pressing against a limit as an expansion signal
- **Checking what was sold against what was provisioned**: comparing a custom plan's entitlements against the order form, which is where entitlements usually drift
- **Adjusting an entitlement**: the one workflow that needs write access, with time-limited overrides recommended for concessions

Plus a short section on why read-only OAuth is the right default for GTM.

## A deliberate choice about tool names

The workflows are written as natural-language prompts rather than as an enumerated MCP tool list. Two reasons: it matches how this audience actually uses the server, and an enumerated list goes stale the moment a tool is added or renamed. I also could not verify the hosted server's exact tool inventory from this repo, and I would rather not publish a list I cannot check. If you want the tool list documented, that belongs on `for-developers.mdx` and should come from whoever owns the server.

## Two fixes to for-developers.mdx

Both were live inconsistencies rather than new work:

- The page `description` advertised "the Claude plugin", but the Claude Plugin section was inside a `{/* ... */}` comment, so the page promised something it did not deliver. **Dropped the section** (its content was "installation directions are coming soon", which is aspirational) and corrected the description.
- The same commented block also contained a **Best Practices** section that was real and useful. Restored it, with the OAuth-over-API-keys guidance folded in.

Added a callout at the top pointing non-engineering readers at the new page.

## Verification

`fern check` passes with 0 errors. Every link target in the new page verified against actual `slug:` frontmatter, including the two deep links into `for-developers` (`#connect-with-oauth`, `#model-context-protocol-mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)