### PR TITLE
DEV-295: connect the sales-led motion end to end

### DIFF
--- a/fern/docs/pages/catalog/custom-plans.mdx
+++ b/fern/docs/pages/catalog/custom-plans.mdx
@@ -42,6 +42,19 @@ When you finalize, you choose an activation strategy that controls when the comp
 
 ![Custom plan invoice paid and active](../../assets/images/catalog/catalog-custom-plan-billing.png)
 
+### Getting the invoice to the customer
+
+The invoice itself is issued through Stripe, which is what gives the customer a way to pay it without you building one. Two settings control how it reaches them:
+
+- **Send invoice** decides whether Stripe emails the invoice to the customer when it is finalized. Leave it off when your team would rather deliver it through the deal thread or a procurement portal.
+- **Days until due** sets the payment window, and it is the same window the **On payment** activation strategy waits on.
+
+Either way the invoice has a Stripe-hosted page where the customer can pay by card or by whatever methods you have enabled in Stripe, so you can pass that link along yourself rather than relying on the email.
+
+Schematic tracks the result. The plan's **Billing** tab shows the invoice status, and when it is paid the company activates on the plan without anyone assigning it. A failed or expired invoice can be retried against the same plan, so a payment problem does not mean rebuilding the deal.
+
+<Info>In sandbox environments, Stripe does not send invoice emails by default. See [Configuring the Catalog](/catalog/configuration) and the [Stripe FAQ](/integrations/stripe-troubleshooting) if an expected invoice email does not arrive.</Info>
+
 ## Versions and migrations
 
 Like standard plans, custom plans are versioned. Editing a finalized custom plan creates a new draft version that you can review and publish, and you can track changes on the plan's **Migrations** tab. Because a custom plan only ever applies to one company, publishing a new version updates that single company. See [Plan Versions](/catalog/plans#plan-versions) for how versioning works.

--- a/fern/docs/pages/playbooks/provisioning-stripe.mdx
+++ b/fern/docs/pages/playbooks/provisioning-stripe.mdx
@@ -6,6 +6,20 @@ slug: playbooks/provisioning
 
 When you connect Stripe to Schematic, any subscription updates will be picked up by Schematic and applied to company profiles. This means that when a new customer signs up, they'll automatically get the right entitlements based on the plan they were sold. Moreover, if that ever changes, Schematic will listen to Stripe to keep access in sync.
 
+## How the handoff works
+
+Provisioning is the step between a customer paying and a customer having access, and Schematic closes it without anyone assigning a plan by hand.
+
+Stripe owns the subscription. When one is created or changed there, Stripe notifies Schematic. Schematic looks at the Stripe product on that subscription, resolves which Schematic plan it corresponds to, and assigns the company to that plan. Entitlements follow from the plan, so the company has access the moment the assignment lands.
+
+The mapping from Stripe product to Schematic plan is what makes this automatic, and it is configured once rather than per deal. See [Plan audiences](/catalog/managing-company-plans#plan-audiences-advanced) for how the rules work, including targeting by trait or by specific company when a billing product is not the right signal.
+
+Because the sync is driven by Stripe rather than polled, the same path handles every subsequent change. An upgrade, a downgrade, or an added subscription item updates entitlements as it happens, and a cancellation removes them.
+
+<Info>This page covers the self-serve and subscription-driven path. Sales-led deals billed by invoice provision through [custom plans](/catalog/custom-plans) instead, where the activation strategy you choose at finalize time decides whether access starts on payment or immediately.</Info>
+
+## Setup
+
 To get setup, follow the steps below.
 
 1. Set up the Stripe integration [here](/integrations/stripe).

--- a/fern/docs/pages/use-cases/custom-deals.mdx
+++ b/fern/docs/pages/use-cases/custom-deals.mdx
@@ -26,6 +26,22 @@ Negotiated plans in the catalog, each tied to exactly one company and carrying i
 
 The lighter-weight option for a smaller concession: one entitlement raised for one company, here 15 Dashboard Prompts per month, with an optional expiry date, while the rest of the plan stays standard. Find it on the company profile.
 
+## The motion end to end
+
+A sales-led deal runs the same five steps every time, and each one has a destination in these docs. The point of doing it this way is that only the first step needs a human after the terms are agreed.
+
+**1. Close the deal.** The order form is signed outside Schematic. What matters here is that the terms it names, entitlements, limits, and price, are the ones you are about to configure.
+
+**2. Turn it into a custom plan.** Build a [custom plan](/catalog/custom-plans) from the company's profile with the negotiated entitlements and pricing, duplicating a standard plan as a starting point if the deal is close to one. No code, and no branch in your application for this account. The [step-by-step guide](/catalog/guides/custom-plans) walks the whole thing.
+
+**3. Invoice them.** Finalizing the plan generates the invoice through Stripe and lets you choose whether Stripe emails it. The invoice has a hosted page the customer pays on. See [Getting the invoice to the customer](/catalog/custom-plans#getting-the-invoice-to-the-customer).
+
+**4. They pay, and the account switches itself on.** With the **On payment** activation strategy, the company activates on the custom plan when the invoice is paid, and entitlements follow from the plan immediately. Nobody assigns anything. Subscription-driven deals provision the same way through [Stripe](/playbooks/provisioning), by mapping the Stripe product to a plan.
+
+**5. Run the account, then renew it.** Usage meters against the plan's entitlements from day one, exceptions are handled with [overrides](/feature-management/overrides) rather than new plans, and expansion is sold with [add-ons](/use-cases/expand-accounts). At renewal, [usage signals](/use-cases/usage-signals) tell you what the customer actually consumed, which is the difference between renegotiating from evidence and renegotiating from a guess. See [Stay ahead of renewals](/use-cases/renewals).
+
+Editing a finalized custom plan creates a new draft version, so a mid-term change follows the same review-then-publish path rather than editing live terms in place.
+
 ## Configure it
 
 - [Custom Plans](/catalog/custom-plans) covers creating a per-company plan for a negotiated, invoiced deal.


### PR DESCRIPTION
Closes [DEV-295](https://linear.app/schematic/issue/DEV-295/document-the-sales-led-motion-end-to-end).

The homepage walks a five-step sales-led sequence. Docs covered the middle well and the ends barely.

## Changes

**`use-cases/custom-deals.mdx`** gains the spine the ticket asks for: all five steps in order, each linking to the page that covers it, so a reader follows the motion instead of assembling it from five pages.

**`catalog/custom-plans.mdx`** gains a "Getting the invoice to the customer" section. This was the real gap. Docs said finalizing generates an invoice and then stopped, never saying how it reaches the customer or how they pay it. Now covers the send-invoice setting, the due window (and that it is the same window `On payment` waits on), the Stripe-hosted invoice page, and what happens on failure.

**`playbooks/provisioning-stripe.mdx`** gets prose so the page stands on its own. It was 37 lines carried almost entirely by two Wistia videos. The new section explains the mechanism (Stripe owns the subscription, notifies Schematic on change, the Stripe product resolves to a plan, entitlements follow) and adds a callout pointing invoiced deals at custom plans, which it never mentioned.

## On the "payment link" question

The plan flagged this as needing confirmation. I did not assert it. There is no `payment_link` object anywhere in the spec, but `CustomPlanBillingResponseData` carries `stripe_invoice_url` alongside `send_invoice` and `days_until_due`. So the docs describe what verifiably exists, a Stripe-hosted invoice page the customer pays on and that you can pass along yourself, without naming "payment link" as a Schematic feature.

**If the site means something more than the Stripe-hosted invoice URL, this needs a follow-up.** Asked on the ticket.

Order forms, ACH, and wire are likewise absent. None has any surface in the API.

## One correction to the plan

The plan said the Plan Audiences screenshots were sitting unused in `assets/images/catalog/`. They are not: `catalog/management.mdx:120` already has a full "Plan audiences (advanced)" section using all three. So `provisioning-stripe.mdx` links there rather than duplicating it, which is what the ticket asked for anyway.

## Review note

The invoice delivery behavior is drawn from `CustomPlanBillingResponseData` field names and from the existing sandbox-email caveat in `configure-catalog.mdx`. **I could not confirm the dashboard labels for the send-invoice and due-window controls at finalize time.** If the UI words them differently, the wording should follow the UI.

`fern check` passes with 0 errors. All link targets and anchors verified, including `#plan-audiences-advanced` and the new `#getting-the-invoice-to-the-customer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)