### PR TITLE
chore(docs): stop advertising theme.colorMode as a working option

### DIFF
--- a/fern/docs/pages/components/pricing-table.mdx
+++ b/fern/docs/pages/components/pricing-table.mdx
@@ -82,7 +82,6 @@ These are the general styling options that will affect the entire pricing table 
     theme: {
       numberOfColumns: 2,
       sectionLayout: "merged",
-      colorMode: "light",
       ...
     }
   }}
@@ -95,7 +94,7 @@ These are the general styling options that will affect the entire pricing table 
 | --- | --- | --- | --- |
 | numberOfColumns | Number of columns to display | 2 | Options: `1`, `2`, `3` |
 | sectionLayout | Layout of the pricing table | `merged` | Options: `merged`, `separated` |
-| colorMode | Color mode of the pricing table | `light` | Options: `light`, `dark` |
+| colorMode | Not currently applied | `light` | Light and dark styling is derived from `card.background`, not from this option. Set a dark `card.background` to get a dark pricing table. |
 | primary | color of any element that is the primary color | `#000000` | Typically this is for buttons, links, and other interactive elements |
 | secondary | Secondary color of the pricing table | `#194BFB` | Typically this is for the background color of the pricing table |
 | danger | Danger color of the pricing table | `#D75A5C` | Typically this is for error messages |
@@ -196,7 +195,6 @@ export default function Pricing() {
         theme: {
           numberOfColumns: 2,
           sectionLayout: "merged",
-          colorMode: "light",
           primary: "#2bbde1",
           secondary: "#2bbde1",
           card: {

--- a/fern/docs/pages/components/standalone-components.mdx
+++ b/fern/docs/pages/components/standalone-components.mdx
@@ -36,7 +36,6 @@ export default function Pricing() {
         theme: {
           numberOfColumns: 2,
           sectionLayout: "merged",
-          colorMode: "light",
           ...
         },
       }}


### PR DESCRIPTION
`theme.colorMode` is documented as a `light`/`dark` switch for the pricing table, but nothing in `@schematichq/schematic-components` reads it. It is only ever written — by the provider's `prefers-color-scheme` listener — and `SchematicEmbed` strips it from the stored design. Light vs. dark is derived entirely from `card.background` luminance via `useIsLightBackground`.

A customer hit this: they set `colorMode: "dark"`, saw no change, and got no error. Tracked as SCHY-44.

Corrects the options table row and drops `colorMode` from the three examples, including the dark-theme example that paired `colorMode: "light"` with a `#0e0e0e` card background — which was contradictory on its face.

Docs-only; verified by grepping `components/src` on `origin/main` of schematic-js for reads of `colorMode` (there are none outside the type declaration and the writes above). Not previewed in a Fern build. Independent of https://github.com/SchematicHQ/schematic-js/pull/1610, which fixes the separate bug the same customer reported.